### PR TITLE
Add the first cut at Chinese support

### DIFF
--- a/webextensions/_locales/zh_CN/messages.json
+++ b/webextensions/_locales/zh_CN/messages.json
@@ -1,0 +1,221 @@
+{
+  "extensionName": { "message": "Flex Confirm Mail" },
+  "extensionDescription": { "message": "确保在发送前根据灵活的规则检查目的地地址和附件" },
+
+
+  "confirmDialogTitle": { "message": "确认目的地的电子邮件地址" },
+  "confirmDialogInternalsCaption": { "message": "注册域名的电子邮件地址" },
+  "confirmDialogExternalsCaption": { "message": "外部域名的电子邮件地址" },
+  "confirmDialogSubjectCaption": { "message": "主题: " },
+  "confirmDialogBodyCaption": { "message": "文本" },
+  "confirmDialogAttachmentsCaption": { "message": "附件" },
+  "confirmDialogAttachmentNameReinputPlaceholder": { "message": "请重新输入附件的名称进行确认" },
+
+  "confirmDialogAccept": { "message": "发送" },
+  "confirmDialogCancel": { "message": "取消" },
+
+
+  "confirmMultipleRecipientDomainsTitle": { "message": "多个域被包含在收件人或抄送目的地中" },
+  "confirmMultipleRecipientDomainsMessage": { "message": "收件人或抄送目的地包含一个以上的域。\n\n$DOMAINS$\n\n一旦发送，所有其他目的地将被告知。 你确定你要发送这个吗？",
+    "placeholders": {
+      "domains": { "content": "$1", "example": "example.com" }
+    }},
+  "confirmMultipleRecipientDomainsAccept": { "message": "发送" },
+  "confirmMultipleRecipientDomainsCancel": { "message": "取消" },
+
+
+  "confirmAttentionDomainsTitle": { "message": "需要特别注意的目的地" },
+  "confirmAttentionDomainsMessage": { "message": "以下目的地属于需要特别注意的领域。\n\n$RECIPIENTS$\n\n请在发送邮件前确认一切正常。",
+    "placeholders": {
+      "recipients": { "content": "$1", "example": "mail@example.com" }
+    }},
+  "confirmAttentionDomainsAccept": { "message": "发送" },
+  "confirmAttentionDomainsCancel": { "message": "取消" },
+
+
+  "confirmAttentionSuffixesTitle": { "message": "需要特别注意的附件类型" },
+  "confirmAttentionSuffixesMessage": { "message": "以下是需要特别注意的带有扩展的附件。\n\n$ATTACHMENTS$\n\n请在发送邮件前确认一切正常。",
+    "placeholders": {
+      "attachments": { "content": "$1", "example": "file.txt" }
+    }},
+  "confirmAttentionSuffixesAccept": { "message": "发送" },
+  "confirmAttentionSuffixesCancel": { "message": "取消" },
+
+  "confirmAttentionSuffixes2Title": { "message": "需要特别注意的其他类型的附件" },
+  "confirmAttentionSuffixes2Message": { "message": "此外，还有以下带有扩展的附件需要特别注意。\n\n$ATTACHMENTS$\n\n请在发送邮件前确认一切正常。",
+    "placeholders": {
+      "attachments": { "content": "$1", "example": "file.txt" }
+    }},
+  "confirmAttentionSuffixes2Accept": { "message": "发送" },
+  "confirmAttentionSuffixes2Cancel": { "message": "取消" },
+
+
+  "confirmAttentionTermsTitle": { "message": "命名需要特别注意的附件" },
+  "confirmAttentionTermsMessage": { "message": "以下附件的名称中含有需要特别注意的单词或短语。\n\n$ATTACHMENTS$\n\n请在发送邮件前确认一切正常。",
+    "placeholders": {
+      "attachments": { "content": "$1", "example": "file.txt" }
+    }},
+  "confirmAttentionTermsAccept": { "message": "发送" },
+  "confirmAttentionTermsCancel": { "message": "取消" },
+
+
+  "alertBlockedDomainsTitle": { "message": "将被封锁的目的地" },
+  "alertBlockedDomainsMessage": { "message": "以下目的地属于要被封锁的域。\n\n$RECIPIENTS$\n\n不可能向这些地址发送邮件。",
+    "placeholders": {
+      "recipients": { "content": "$1", "example": "mail@example.com" }
+    }},
+  "alertBlockedDomainsAccept": { "message": "关闭" },
+
+
+  "reconfirmAccept":    { "message": "发送" },
+  "reconfirmCancel":    { "message": "取消" },
+  "alertBlockedAccept": { "message": "关闭" },
+
+
+  "countdownDialogTitle": { "message": "倒计时" },
+  "countdownDialogMessage_before": { "message": "" },
+  "countdownDialogMessage_after": { "message": "秒内发送电子邮件" },
+  "countdownDialogSkip": { "message": "现在发送" },
+  "countdownDialogCancel": { "message": "取消" },
+
+
+  "showLastNameFirst": { "message": "true" },
+
+
+  "config_title": { "message": "设置Flex Confirm Mail" },
+
+  "config_recipients_caption": { "message": "目的地" },
+
+  "config_confirmationMode_caption": { "message": "发送前确认目的地:" },
+  "config_confirmationMode_always_label": { "message": "经常检查" },
+  "config_confirmationMode_onModified_label": { "message": "只有在有误导风险的情况下才进行检查" },
+  "config_confirmationMode_onModified_description_before": { "message": "当收件人发生变化时，当文本从包含不同收件人的电子邮件中复制和粘贴时；以及" },
+  "config_confirmationMode_onModified_description_after": { "message": "粘贴长于字符的字符串时进行检查。" },
+  "config_confirmationMode_never_label": { "message": "不要总是检查" },
+
+  "config_internalDomains_caption": { "message": "将被视为组织内的电子邮件地址的域名。" },
+  "config_internalDomains_input_placeholder": { "message": "一行一行地输入域名（例子：example.com）" },
+
+  "config_skipConfirmationForInternalMail_label": { "message": "在发送所有目的地为注册域名的电子邮件时，没有确认对话" },
+  "config_minConfirmationRecipientsCount_label_before": { "message": "如果有" },
+  "config_minConfirmationRecipientsCount_label_after": { "message": "个或更少的目的地，则不显示确认对话（设置为0，表示总是检查）" },
+  "config_confirmMultipleRecipientDomains_label": { "message": "当收件人或抄送对象包含一个以上的域时发出警告" },
+  "config_allowCheckAllInternals_label": { "message": "允许对组织中的目的地进行批量检查" },
+  "config_allowCheckAllExternals_label": { "message": "允许对外部目的地进行批量检查" },
+
+
+  "config_userRules_caption":              { "message": "附加规则" },
+  "config_userRules_add":                  { "message": "新规则" },
+  "config_userRules_remove_label":         { "message": "×" },
+  "config_userRules_remove_tooltiptext":   { "message": "删除规则。" },
+  "config_userRules_remove_confirmMessage": { "message": "你真的想删除「$NAME$」吗？",
+    "placeholders": {
+      "name": { "content": "$1", "example": "rule name" }
+    }},
+  "config_userRules_remove_accept":        { "message": "删除" },
+  "config_userRules_remove_cancel":        { "message": "取消" },
+  "config_userRules_moveUp_label":         { "message": "▲" },
+  "config_userRules_moveUp_tooltiptext":   { "message": "向上移动" },
+  "config_userRules_moveDown_label":       { "message": "▼" },
+  "config_userRules_moveDown_tooltiptext": { "message": "向下移动" },
+
+  "config_userRule_name_placeholder":    { "message": "名称" },
+  "config_userRule_name_button_label":   { "message": "编辑" },
+  "config_userRule_enabled_tooltiptext": { "message": "勾选方框以激活该规则" },
+
+  "config_userRule_matchTarget_caption":          { "message": "匹配的目标:" },
+  "config_userRule_matchTarget_recipientDomain":  { "message": "目的地的域名部分" },
+  "config_userRule_matchTarget_attachmentName":   { "message": "附件的名称" },
+  "config_userRule_matchTarget_attachmentSuffix": { "message": "附件的文件扩展名" },
+  "config_userRule_matchTarget_subject":          { "message": "主题" },
+  "config_userRule_matchTarget_body":             { "message": "文本" },
+  "config_userRule_matchTarget_subjectOrBody":    { "message": "主题和文本" },
+
+  "config_userRule_highlight_caption_general":    { "message": "满足条件时突出显示:" },
+  "config_userRule_highlight_caption_recipient":  { "message": "突出相关的目的地:" },
+  "config_userRule_highlight_caption_attachment": { "message": "突出显示相关的附件:" },
+  "config_userRule_highlight_never":              { "message": "没有突出显示" },
+  "config_userRule_highlight_always":             { "message": "始终突出显示" },
+  "config_userRule_highlight_withAttachments":    { "message": "只有在有附件的情况下" },
+  "config_userRule_highlight_externals":          { "message": "只有当外部地址包含在目的地中时" },
+  "config_userRule_highlight_externalsWithAttachments": { "message": "只有在目的地中包括一个外部地址并且有一个附件的情况下" },
+
+  "config_userRule_action_caption_general":          { "message": "如果条件得到满足:" },
+  "config_userRule_action_caption_recipient":        { "message": "如果适用目的地:" },
+  "config_userRule_action_caption_attachment":       { "message": "如果有一个相关的附件:" },
+  "config_userRule_action_none":                     { "message": "（不要警告）" },
+  "config_userRule_action_reconfirmAlways":          { "message": "总是重新确认" },
+  "config_userRule_action_reconfirmWithAttachments": { "message": "只有在有任何附件时才重新确认" },
+  "config_userRule_action_reconfirmExternals":       { "message": "只有在有任何外部收件人时才重新确认" },
+  "config_userRule_action_reconfirmExternalsWithAttachments": { "message": "只有在有任何外部收件人和附件时才重新确认" },
+  "config_userRule_action_blockAlways":              { "message": "不允许总是发送电子邮件" },
+  "config_userRule_action_blockWithAttachments":     { "message": "不允许只在有任何附件的情况下发送邮件" },
+  "config_userRule_action_blockExternals":           { "message": "不允许只在有任何外部收件人的情况下发送邮件" },
+  "config_userRule_action_blockExternalsWithAttachments": { "message": "不允许只在有任何外部收件人和附件的情况下发送邮件" },
+
+  "config_userRule_itemsLocal_caption":                      { "message": "使用手动编辑列表" },
+  "config_userRule_itemsLocal_placeholder_recipientDomain":  { "message": "一行一行地输入域名（例子：example.com）" },
+  "config_userRule_itemsLocal_placeholder_attachmentName":   { "message": "一行一行地输入单词（例子：重要、保密）" },
+  "config_userRule_itemsLocal_placeholder_attachmentSuffix": { "message": "一行一行地输入文件扩展名（例子：.exe、.pdf）" },
+  "config_userRule_itemsLocal_placeholder_subject":          { "message": "一行一行地输入单词（例子：重要、保密）" },
+  "config_userRule_itemsLocal_placeholder_body":             { "message": "一行一行地输入单词（例子：重要、保密）" },
+  "config_userRule_itemsLocal_placeholder_subjectOrBody":    { "message": "一行一行地输入单词（例子：重要、保密）" },
+  "config_userRule_itemsFile_caption":                             { "message": "使用以文件形式给出的列表" },
+  "config_userRule_itemsFile_button_label":                        { "message": "选择..." },
+  "config_userRule_itemsFile_button_dialogTitle_recipientDomain":  { "message": "选择一个域的列表" },
+  "config_userRule_itemsFile_button_dialogTitle_attachmentName":   { "message": "选择一个单词列表" },
+  "config_userRule_itemsFile_button_dialogTitle_attachmentSuffix": { "message": "选择扩展列表" },
+  "config_userRule_itemsFile_button_dialogTitle_subject":          { "message": "选择一个单词列表" },
+  "config_userRule_itemsFile_button_dialogTitle_body":             { "message": "选择一个单词列表" },
+  "config_userRule_itemsFile_button_dialogTitle_subjectOrBody":    { "message": "选择一个单词列表" },
+  "config_userRule_itemsFile_button_dialogDisplayName":            { "message": "列表文件" },
+  "config_userRule_itemsFile_input_placeholder_recipientDomain":   { "message": "输入文件的路径（例子：\\\\FileServer\\Shared\\domains.txt）" },
+  "config_userRule_itemsFile_input_placeholder_attachmentName":    { "message": "输入文件的路径（例子：\\\\FileServer\\Shared\\terms.txt）" },
+  "config_userRule_itemsFile_input_placeholder_attachmentSuffix":  { "message": "输入文件的路径（例子：\\\\FileServer\\Shared\\suffixes.txt）" },
+  "config_userRule_itemsFile_input_placeholder_subject":           { "message": "输入文件的路径（例子：\\\\FileServer\\Shared\\suffixes.txt）" },
+  "config_userRule_itemsFile_input_placeholder_body":              { "message": "输入文件的路径（例子：\\\\FileServer\\Shared\\suffixes.txt）" },
+  "config_userRule_itemsFile_input_placeholder_subjectOrBody":     { "message": "输入文件的路径（例子：\\\\FileServer\\Shared\\suffixes.txt）" },
+  "config_userRule_confirmTitle_caption":                    { "message": "警告标题:" },
+  "config_userRule_confirmMessage_caption_recipientDomain":  { "message": "警告信息 (该地址被放置在标有 \"%S\" 的位置。" },
+  "config_userRule_confirmMessage_caption_attachmentName":   { "message": "警告信息 (附件名称被放置在标有 \"%S\" 的位置):" },
+  "config_userRule_confirmMessage_caption_attachmentSuffix": { "message": "警告信息 (附件名称被放置在标有 \"%S\" 的位置):" },
+  "config_userRule_confirmMessage_caption_subject":          { "message": "警告信息 (该词被放置在标有 \"%S\" 的位置):" },
+  "config_userRule_confirmMessage_caption_body":             { "message": "警告信息 (该词被放置在标有 \"%S\" 的位置):" },
+  "config_userRule_confirmMessage_caption_subjectOrBody":    { "message": "警告信息 (该词被放置在标有 \"%S\" 的位置):" },
+
+
+  "config_attentionDomains_caption": { "message": "需要特别注意的外部域目的地" },
+  "config_blockedDomains_caption": { "message": "禁止向其传输的目的地" },
+  "config_requireCheckAttachment_label": { "message": "要求对附件进行确认" },
+  "config_attentionSuffixesConfirm_label": { "message": "如果带有这些扩展名的文件被附在发给外部域名的电子邮件中，则再次发出警告" },
+  "config_attentionSuffixes2Confirm_label": { "message": "如果带有这些扩展名的文件被附在发给外部域名的电子邮件中，则再次发出进一步警告" },
+  "config_attentionTermsConfirm_label": { "message": "如果一个名称中含有这些字的文件被附在发给外部域的电子邮件中，则再次发出警告" },
+
+  "config_attachments_caption": { "message": "附件" },
+
+  "config_requireReinputAttachmentNames_label": { "message": "如果收件人有一个外部域名，要求手动输入附件名称" },
+  "config_allowCheckAllAttachments_label": { "message": "允许批量控制附件的复选框" },
+
+
+  "config_misc_caption": { "message": "其他" },
+
+  "config_showCountdown_label": { "message": "在按下[发送]按钮后, 会有" },
+  "config_countdownSeconds_label": { "message": "秒钟的倒计时，然后是实际传输。" },
+  "config_countdownAllowSkip_label": { "message": "允许跳过计数并立即发送" },
+
+  "config_requireCheckSubject_label": { "message": "要求确认主题" },
+  "config_requireCheckBody_label": { "message": "要求确认电子邮件的文本" },
+
+  "config_highlightExternalDomains_label": { "message": "突出显示外部域名目的地的地址" },
+  "config_largeFontSizeForAddresses_label": { "message": "用较大的字体显示电子邮件地址" },
+  "config_alwaysLargeDialog_label": { "message": "始终以较大的尺寸打开确认对话框" },
+  "config_topMessage_label": { "message": "确认对话的开头信息:" },
+  "config_emphasizeTopMessage_label": { "message": "突出显示信息" },
+  "config_emphasizeRecipientType_label": { "message": "高亮显示目的地类型（收件人/抄送/密件）" },
+
+
+  "config_debug_caption": { "message": "对于开发商来说" },
+
+  "config_debug_label": { "message": "调试模式" },
+  "config_all_caption": { "message": "所有设置" }
+}


### PR DESCRIPTION
The older XPCOM addon supported Chinese locale, but we did
not ported the support to new Web Extension. This patch is
an attempt to fix that.

Note: These messages are translated from the Japanese locale
(and sometimes, English locale) using DeepL Pro License.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>