### PR TITLE
Add configuration for automated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,16 @@
+# .github/release.yml
+
+changelog:
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: New Features 🎉
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
To make release notes automatically, suggest using "automatically-generated-release-notes" feature.
With this feature, we can pick up all merged PR.

Currently, bug and enhancement labels exist, so just reuse it.
NOTE: breaking-change label does not exist yet.

See
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes