### PR TITLE
github: add build action for FlexConfirmMail

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,0 +1,45 @@
+on: [push]
+name: Build FlexConfirmMail
+jobs:
+  build:
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 'stable'
+      - run: go version
+      - name: Install go-msi
+        run: choco install go-msi zip
+      # jq wixtoolset is already installed on windows-2019 image
+      - name: Setup PATH
+        run: |
+          echo "c:/ProgramData/chocolatey/bin" >> $Env:GITHUB_PATH
+          echo "c:/Program Files/go-msi" >> $Env:GITHUB_PATH
+          echo "c:/Program Files (x86)/WiX Toolset v3.11/bin" >> $Env:GITHUB_PATH
+      - name: Show PATH
+        run: |
+          echo $Env:PATH
+          echo $Env:GOPATH
+      - name: Install gox
+        run: go install github.com/mitchellh/gox@latest
+      - name: Make xpi
+        run: make
+      - name: Make Installer
+        run: make host
+        env:
+          GOPATH: C:\Users\runneradmin\go
+      - name: Make Native Messaging Host Installer
+        run: |
+          .\webextensions\native-messaging-host\build_msi.bat
+          dir
+          xcopy /I /Y .\webextensions\native-messaging-host\*.msi .
+      - name: Upload assets
+        uses: actions/upload-artifact@v3
+        with:
+          name: Assets
+          path: |
+            *.xpi
+            *.zip
+            *.msi
+

--- a/webextensions/native-messaging-host/build.sh
+++ b/webextensions/native-messaging-host/build.sh
@@ -70,7 +70,7 @@ prepare_msi_sources() {
   touch "$build_msi_bat"
   echo -e "set MSITEMP=%USERPROFILE%\\\\temp%RANDOM%\r" >> "$build_msi_bat"
   echo -e "set SOURCE=%~dp0\r" >> "$build_msi_bat"
-  echo -e "xcopy \"%SOURCE%\\*\" \"%MSITEMP%\" /S /I \r" >> "$build_msi_bat"
+  echo -e "xcopy \"%SOURCE%*\" \"%MSITEMP%\" /S /I \r" >> "$build_msi_bat"
   echo -e "cd /d \"%MSITEMP%\" \r" >> "$build_msi_bat"
   echo -e "copy 386\\host.exe \"%cd%\\\" \r" >> "$build_msi_bat"
   echo -e "go-msi.exe make --msi ${msi_basename}-386.msi --version ${addon_version} --src templates --out \"%cd%\\outdir\" --arch 386 \r" >> "$build_msi_bat"

--- a/webextensions/native-messaging-host/build.sh
+++ b/webextensions/native-messaging-host/build.sh
@@ -71,14 +71,14 @@ prepare_msi_sources() {
   echo -e "set MSITEMP=%USERPROFILE%\\\\temp%RANDOM%\r" >> "$build_msi_bat"
   echo -e "set SOURCE=%~dp0\r" >> "$build_msi_bat"
   echo -e "xcopy \"%SOURCE%\\*\" \"%MSITEMP%\" /S /I \r" >> "$build_msi_bat"
-  echo -e "cd \"%MSITEMP%\" \r" >> "$build_msi_bat"
+  echo -e "cd /d \"%MSITEMP%\" \r" >> "$build_msi_bat"
   echo -e "copy 386\\host.exe \"%cd%\\\" \r" >> "$build_msi_bat"
   echo -e "go-msi.exe make --msi ${msi_basename}-386.msi --version ${addon_version} --src templates --out \"%cd%\\outdir\" --arch 386 \r" >> "$build_msi_bat"
   echo -e "del host.exe \r" >> "$build_msi_bat"
   echo -e "copy amd64\\host.exe \"%cd%\\\" \r" >> "$build_msi_bat"
   echo -e "go-msi.exe make --msi ${msi_basename}-amd64.msi --version ${addon_version} --src templates --out \"%cd%\\outdir\" --arch amd64 \r" >> "$build_msi_bat"
   echo -e "xcopy *.msi \"%SOURCE%\" /I /Y \r" >> "$build_msi_bat"
-  echo -e "cd \"%SOURCE%\" \r" >> "$build_msi_bat"
+  echo -e "cd /d \"%SOURCE%\" \r" >> "$build_msi_bat"
   echo -e "rd /S /Q \"%MSITEMP%\" \r" >> "$build_msi_bat"
 }
 


### PR DESCRIPTION
# Problem

We need to set up build environment, respectively.

# Expected

For every commit, we can build binary via GitHub actions.
It make easy to prepare pre-built binary without development environment.


