### PR TITLE
github: do not pack xul version of xpi

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Install gox
         run: go install github.com/mitchellh/gox@latest
       - name: Make xpi
-        run: make
+        run: cd webextensions && make && cp *.xpi ..\
       - name: Make Installer
         run: make host
         env:


### PR DESCRIPTION
# Which issue(s) this PR fixes:

Related to #19, but not remove XUL version yet.


# What this PR does / why we need it:

In the previous PR, it build deprecated XUL version of xpi too.
In this PR, it build only webextension version of xpi.

# How to verify the fixed issue:

Run GitHub actions and see built assets.

## Expected result:

No flex-confirm-mail.xpi in assets.
