### PR TITLE
Apply unlocked managed value as default value

### DIFF
--- a/webextensions/common/matching-rules.js
+++ b/webextensions/common/matching-rules.js
@@ -8,6 +8,10 @@
 import * as Constants from './constants.js';
 import * as RecipientParser from './recipient-parser.js';
 
+function clone(object) {
+  return JSON.parse(JSON.stringify(object));
+}
+
 const BASE_RULE = {
   id:             '', // arbitrary unique string (auto generated)
   name:           '', // arbitrary visible name in the UI
@@ -24,11 +28,11 @@ const BASE_RULE = {
 
 export class MatchingRules {
   constructor({ base, baseRules, overrideBase, overrideBaseRules, user, userRules, override, overrideRules } = {}) {
-    this.$baseRules     = base     || baseRules     || [];
-    this.$overrideBaseRules = overrideBase || overrideBaseRules || [];
+    this.$baseRules     = clone(base     || baseRules     || []);
+    this.$overrideBaseRules = clone(overrideBase || overrideBaseRules || []);
     this.$mergedBaseRulesById = {};
-    this.$userRules     = user     || userRules     || [];
-    this.$overrideRules = override || overrideRules || [];
+    this.$userRules     = clone(user     || userRules     || []);
+    this.$overrideRules = clone(override || overrideRules || []);
     this.$load();
   }
 
@@ -44,16 +48,16 @@ export class MatchingRules {
         let merged = mergedRulesById[id];
         if (!merged) {
           merged = mergedRulesById[id] = {
-            ...JSON.parse(JSON.stringify(BASE_RULE)),
+            ...clone(BASE_RULE),
             id,
             $lockedKeys: [],
           };
           mergedRules.push(merged);
         }
-        Object.assign(merged, rule);
+        Object.assign(merged, clone(rule));
         if (rules === this.$baseRules ||
             rules === this.$overrideBaseRules)
-          this.$mergedBaseRulesById[id] = JSON.parse(JSON.stringify(merged));
+          this.$mergedBaseRulesById[id] = clone(merged);
         if (locked) {
           merged.$lockedKeys.push(...Object.keys(rule).filter(key => key != 'id'));
         }
@@ -155,7 +159,7 @@ export class MatchingRules {
     const id = `rule-${Date.now()}-${parseInt(Math.random() * 56632)}`;
     const rule = {
       id,
-      ...JSON.parse(JSON.stringify(BASE_RULE)),
+      ...clone(BASE_RULE),
       ...params,
       enabled: true,
       $lockedKeys: [],

--- a/webextensions/manifest.json
+++ b/webextensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "4.1.5.1",
+  "version": "4.1.5",
   "author": "ClearCode Inc.",
   "description": "__MSG_extensionDescription__",
   "permissions": [

--- a/webextensions/manifest.json
+++ b/webextensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "4.1.5",
+  "version": "4.1.5.1",
   "author": "ClearCode Inc.",
   "description": "__MSG_extensionDescription__",
   "permissions": [


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

There is a confusing behavior around multiple level configs from GPO of Outlook, GPO of Thunderbird, and policies.json. This PR stabilize it based on the order of config sources described at here: https://github.com/piroor/webextensions-lib-configs/blob/f950a9a43694cce90ed922318d1da3fe753ae153/Configs.js#L10-L23

# How to verify the fixed issue:

* Install FlexConfirmMail to Thunderbird and configure it. 
* Configure GPO of FlexConfirmMail for Outlook.
* Configure FlexConfirmMail with policies.json.
* Start Thunderbird and confirm that configs are applied with the order described at https://github.com/piroor/webextensions-lib-configs/blob/f950a9a43694cce90ed922318d1da3fe753ae153/Configs.js#L10-L23

## The steps to verify:

1. Prepare the environment.
   1. Prepare a Windows environment, e.g. Windows 10 22H2.
   2. Download policy template of FlexConfirmMail for Outlook: https://github.com/FlexConfirmMail/Outlook/tree/master/policy
   3. Put `*,admx` under `C:\Windows\PolicyDefinitions\`
   4. Put `en-US` under `C:\Windows\PolicyDefinitions\` (unify to the existing one)
   5. Install Thunderbird.
   6. Start Thunderbird.
   7. Install Native Messaging Host for FlexConfirmMail.
   8. Install FlexConfirmMail.
2. Set multiple level configs for FlexCofnirmMail.
   1. Go to FlexConfirmMail's options and set the "count down seconds" to "10".
   2. Start `gpedit.msc`.
   3. Set "Delay sending a message by N seconds" of FlexConfirmMail for Outlook as "30".
   4. Set "policies.json" as:
      ```json
      {
        "policies": {
          "3rdparty": {
            "Extensions": {
              "flexible-confirm-mail@clear-code.com": {
                "countdownSeconds": 60,
                "countdownSeconds:locked": true
              }
            }
          }
        }
      }
      ```
   5. Exit Thunderbird.
3. Start Thunderbird, and go to FlexConfirmMail's options page.
   * Expected value for "count down seconds" is: 60 (from policies.json, locked)
4. Exit Thunderbird.
5. Set "policies.json" as:
   ```json
   {
     "policies": {
       "3rdparty": {
         "Extensions": {
           "flexible-confirm-mail@clear-code.com": {
             "countdownSeconds": 60,
             "countdownSeconds:locked": false
           }
         }
       }
     }
   }
   ```
6. Start Thunderbird, and go to FlexConfirmMail's options page.
   * Expected value for "count down seconds" is: 10 (from user value)
7. Reset "countdownSeconds" to default.
8. Exit Thunderbird.
9. Start Thunderbird, and go to FlexConfirmMail's options page.
   * Expected value for "count down seconds" is: 60 (from policies.json, not locked)
10. Exit Thunderbird.
11. Delete "policies.json".
12. Start Thunderbird, and go to FlexConfirmMail's options page.
    * Expected value for "count down seconds" is: 30 (from GPO for Outlook)
13. Exit Thunderbird.
14. Start `gpedit.msc`.
15. Unconfigure "Delay sending a message by N seconds" of FlexConfirmMail for Outlook.
16. Start Thunderbird, and go to FlexConfirmMail's options page.
    * Expected value for "count down seconds" is: 5 (built-in default)


## Expected result:

Described in the previous section.