### PR TITLE
Bump version to 4.1.6

### DIFF
--- a/webextensions/manifest.json
+++ b/webextensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "author": "ClearCode Inc.",
   "description": "__MSG_extensionDescription__",
   "permissions": [

--- a/webextensions/native-messaging-host/host.go
+++ b/webextensions/native-messaging-host/host.go
@@ -24,7 +24,7 @@ import (
 	"time"
 )
 
-const VERSION = "4.1.5";
+const VERSION = "4.1.6";
 
 
 var RunInCLI bool


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Increments the version to 4.1.6 for a new release.

# How to verify the fixed issue:

Install the built package and check its display version.

## The steps to verify:

1. Run `make`.
2. Install xpi to Thunderbird.
3. Enter webextensions/native-messaging-host and run `build_msi.bat` to build MSI.
4. Run the built MSI to install the native messaging host.
5. Go to the list of installed applications on Windows.
    * Verify the installed version is `4.1.6`.
6. Drag the built XPI and drop onto Thudnerbird's addons manager.
    * Verify the installed version is `4.1.6`.

## Expected result:

The installed version is displayed as `4.1.6`.