### PR TITLE
Staple notarization status to the signed package for offline install

### DIFF
--- a/webextensions/native-messaging-host/build_pkg.sh
+++ b/webextensions/native-messaging-host/build_pkg.sh
@@ -25,4 +25,5 @@ fi
 if codesign -dvvv ./host 2>&1 | grep "Authority=$APP_CERT_NAME" > /dev/null &&
    pkgutil --check-signature "./$NMH_NAME.signed.pkg" > /dev/null; then
   xcrun notarytool submit "$PWD/$NMH_NAME.signed.pkg" --keychain-profile "Pkg Signing" --wait
+  xcrun stapler staple "$PWD/$NMH_NAME.signed.pkg"
 fi


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

If we just notarize the pkg, the Mac machine needs to be online before using notarized pkg. Stapling allows us to run the pkg without online validation.

# How to verify the fixed issue:

Try to install stapled pkg without any error even if the Mac machine is offline.

## The steps to verify:

1. Prepare a signed, notarized and stapled pkg.
2. Copy the file to another Mac machine.
3. Make the machine offline.
4. Install the pkg.

## Expected result:

The pkg should be installed successfully.