### PR TITLE
Fix a typo in sendToHost

### DIFF
--- a/webextensions/common/common.js
+++ b/webextensions/common/common.js
@@ -263,7 +263,7 @@ export function log(message, ...args) {
 
 export async function sendToHost(message) {
   try {
-    message.loggging = message.loggging && configs.debug;
+    message.logging = message.logging && configs.debug;
     message.debug = message.debug && configs.debug;
     const response = await browser.runtime.sendNativeMessage(Constants.HOST_ID, message);
     if (!response || typeof response != 'object')


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Fix  a typo in sending a message to host.

```
loggging ->
logging
```

# How to verify the fixed issue:

N/A
It is not used effectively from webextension.

## Expected result:

N/A
