### PR TITLE
Detect files with specified extensions correctly

### DIFF
--- a/webextensions/common/matching-rules.js
+++ b/webextensions/common/matching-rules.js
@@ -121,7 +121,7 @@ export class MatchingRules {
           break;
 
         case Constants.MATCH_TO_ATTACHMENT_SUFFIX:
-          this._$attachmentMatchers[rule.id] = new RegExp(`\\.(${rule.items.map(suffix => this.$sanitizeRegExpSource(suffix).replace(/^\./, '')).join('|')})$`, 'i');
+          this._$attachmentMatchers[rule.id] = new RegExp(`\\.(${rule.items.map(suffix => this.$sanitizeRegExpSource(suffix.replace(/^\./, ''))).join('|')})$`, 'i');
           break;
 
         case Constants.MATCH_TO_SUBJECT:


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

`test_classifyAttachments` fails due to some changes introduced at old versions. This fixes the implementation to pass the existing test.

# How to verify the fixed issue:

Run the automated test.

## The steps to verify:

1. Clone this repository.
2. cd `webextensions`.
3. run `npm install`.
4. run `npm run test`. 

## Expected result:

All tests should pass.