### PR TITLE
Wildcard support

### DIFF
--- a/webextensions/_locales/en/messages.json
+++ b/webextensions/_locales/en/messages.json
@@ -95,8 +95,9 @@
 
   "config_internalDomains_caption": { "message": "Domains treated as internals" },
   "config_internalDomains_input_placeholder": { "message": "Input domain names per line (e.g. example.com)" },
+  "config_internalDomains_input_description": { "message": "Wildcards (* and ?) are available." },
   "config_fixedInternalDomains_label": { "message": "Following domains are listed by the system administrator." },
-  "config_fixedInternalDomains_label_editable": { "message": "You can deactivate individual domains by adding \"-\" at the beginning." },
+  "config_fixedInternalDomains_label_editable": { "message": "You can deactivate individual domains by adding \"-\" at the beginning, and wildcards (* and ?) are available." },
 
   "config_skipConfirmationForInternalMail_label": { "message": "Skip confirmation if all recipients are internals" },
   "config_minConfirmationRecipientsCount_label_before": { "message": "Skip confirmation if there are/is only" },
@@ -170,6 +171,7 @@
   "config_userRule_itemsLocal_placeholder_subject":          { "message": "Input a term per line (e.g. important, confidential)" },
   "config_userRule_itemsLocal_placeholder_body":             { "message": "Input a term per line (e.g. important, confidential)" },
   "config_userRule_itemsLocal_placeholder_subjectOrBody":    { "message": "Input a term per line (e.g. important, confidential)" },
+  "config_userRule_itemsLocal_description":                  { "message": ": wildcards (* and ?) are available." },
   "config_userRule_itemsFile_caption":                             { "message": "Use a list given as a file" },
   "config_userRule_itemsFile_button_label":                        { "message": "Choose…" },
   "config_userRule_itemsFile_button_dialogTitle_recipientDomain":  { "message": "Choose a list of domain names" },

--- a/webextensions/_locales/ja/messages.json
+++ b/webextensions/_locales/ja/messages.json
@@ -95,8 +95,9 @@
 
   "config_internalDomains_caption": { "message": "組織内として扱うメールアドレスのドメイン名" },
   "config_internalDomains_input_placeholder": { "message": "ドメイン名を1行ずつ入力（例：example.com）" },
+  "config_internalDomains_input_description": { "message": "ワイルドカード（*および?）を使用可能です" },
   "config_fixedInternalDomains_label": { "message": "システム管理者によって、以下のドメインが組織内ドメインとして指定されています。" },
-  "config_fixedInternalDomains_label_editable": { "message": "ドメイン名の先頭に「-」をつけると、ドメインを除外することができます。" },
+  "config_fixedInternalDomains_label_editable": { "message": "ドメイン名の先頭に「-」をつけると、ドメインを除外することができます。また、ワイルドカード（*および?）も使用可能です。" },
 
   "config_skipConfirmationForInternalMail_label": { "message": "すべての宛先が登録済みドメインのメール送信時は確認ダイアログを表示しない" },
   "config_minConfirmationRecipientsCount_label_before": { "message": "宛先が" },
@@ -170,6 +171,7 @@
   "config_userRule_itemsLocal_placeholder_subject":          { "message": "語句を1行ずつ入力（例：危険、社外秘）" },
   "config_userRule_itemsLocal_placeholder_body":             { "message": "語句を1行ずつ入力（例：危険、社外秘）" },
   "config_userRule_itemsLocal_placeholder_subjectOrBody":    { "message": "語句を1行ずつ入力（例：危険、社外秘）" },
+  "config_userRule_itemsLocal_description":                  { "message": "：ワイルドカード（*および?）を使用可能です" },
   "config_userRule_itemsFile_caption":                             { "message": "ファイル形式のリストを使用" },
   "config_userRule_itemsFile_button_label":                        { "message": "参照..." },
   "config_userRule_itemsFile_button_dialogTitle_recipientDomain":  { "message": "ドメインのリストを選択" },

--- a/webextensions/common/matching-rules.js
+++ b/webextensions/common/matching-rules.js
@@ -117,23 +117,23 @@ export class MatchingRules {
           break;
 
         case Constants.MATCH_TO_ATTACHMENT_NAME:
-          this._$attachmentMatchers[rule.id] = new RegExp(`(${rule.items.map(this.$sanitizeRegExpSource).join('|')})`, 'i');
+          this._$attachmentMatchers[rule.id] = new RegExp(`(${rule.items.map(this.$toRegExpSource).join('|')})`, 'i');
           break;
 
         case Constants.MATCH_TO_ATTACHMENT_SUFFIX:
-          this._$attachmentMatchers[rule.id] = new RegExp(`\\.(${rule.items.map(suffix => this.$sanitizeRegExpSource(suffix.replace(/^\./, ''))).join('|')})$`, 'i');
+          this._$attachmentMatchers[rule.id] = new RegExp(`\\.(${rule.items.map(suffix => this.$toRegExpSource(suffix.replace(/^\./, ''))).join('|')})$`, 'i');
           break;
 
         case Constants.MATCH_TO_SUBJECT:
-          this._$subjectMatchers[rule.id] = new RegExp(`(${rule.items.map(this.$sanitizeRegExpSource).join('|')})`, 'gi');
+          this._$subjectMatchers[rule.id] = new RegExp(`(${rule.items.map(this.$toRegExpSource).join('|')})`, 'gi');
           break;
 
         case Constants.MATCH_TO_BODY:
-          this._$bodyMatchers[rule.id] = new RegExp(`(${rule.items.map(this.$sanitizeRegExpSource).join('|')})`, 'gi');
+          this._$bodyMatchers[rule.id] = new RegExp(`(${rule.items.map(this.$toRegExpSource).join('|')})`, 'gi');
           break;
 
         case Constants.MATCH_TO_SUBJECT_OR_BODY: {
-          const sanitizedItems = rule.items.map(this.$sanitizeRegExpSource).join('|');
+          const sanitizedItems = rule.items.map(this.$toRegExpSource).join('|');
           this._$subjectMatchers[rule.id] = new RegExp(`(${sanitizedItems})`, 'gi');
           this._$bodyMatchers[rule.id] = new RegExp(`(${sanitizedItems})`, 'gi');
         }; break;
@@ -143,8 +143,13 @@ export class MatchingRules {
       }
     }
   }
-  $sanitizeRegExpSource(source) { // https://stackoverflow.com/questions/6300183/sanitize-string-of-regex-characters-before-regexp-build
-    return source.replace(/[#-.]|[[-^]|[?|{}]/g, '\\$&');
+  $toRegExpSource(source) {
+    // https://stackoverflow.com/questions/6300183/sanitize-string-of-regex-characters-before-regexp-build
+    const sanitized = source.replace(/[#-.]|[[-^]|[?|{}]/g, '\\$&');
+
+    const wildcardAccepted = sanitized.replace(/\\\*/g, '.*').replace(/\\\?/g, '.');
+
+    return wildcardAccepted;
   }
 
   get all() {

--- a/webextensions/common/matching-rules.js
+++ b/webextensions/common/matching-rules.js
@@ -67,10 +67,10 @@ export class MatchingRules {
     this.$rulesById = mergedRulesById;
   }
 
-  get $matchedDomainSets() {
-    if (!this._$matchedDomainSets)
+  get $domainMatchers() {
+    if (!this._$domainMatchers)
       this.$prepareMatchers();
-    return this._$matchedDomainSets;
+    return this._$domainMatchers;
   }
 
   get $attachmentMatchers() {
@@ -92,7 +92,7 @@ export class MatchingRules {
   }
 
   $prepareMatchers() {
-    this._$matchedDomainSets = {};
+    this._$domainMatchers = {};
     this._$attachmentMatchers = {};
     this._$subjectMatchers = {};
     this._$bodyMatchers = {};
@@ -113,7 +113,7 @@ export class MatchingRules {
             uniqueDomains.delete(negativeItem);
             uniqueDomains.delete(`-${negativeItem}`);
           }
-          this._$matchedDomainSets[rule.id] = uniqueDomains;
+          this._$domainMatchers[rule.id] = new RegExp(`^(${[...uniqueDomains].map(this.$toRegExpSource).join('|')})$`, 'i');
           break;
 
         case Constants.MATCH_TO_ATTACHMENT_NAME:
@@ -304,8 +304,8 @@ export class MatchingRules {
       for (const recipient of recipients) {
         const parsedRecipient = typeof recipient == 'string' ? RecipientParser.parse(recipient) : recipient;
 
-        for (const [id, domains] of Object.entries(this.$matchedDomainSets)) {
-          if (!domains.has(parsedRecipient.domain))
+        for (const [id, matcher] of Object.entries(this.$domainMatchers)) {
+          if (!matcher.test(parsedRecipient.domain))
             continue;
 
           const rule = this.get(id);

--- a/webextensions/options/init.js
+++ b/webextensions/options/init.js
@@ -260,7 +260,8 @@ function rebuildUserRulesUI() {
                             name=${safeAttrValue('userRule-ui-itemsSource:' + id)}
                             type="radio"
                             value="${Constants.SOURCE_LOCAL_CONFIG}">
-                     ${safeLocalizedText('config_userRule_itemsLocal_caption')}</label>
+                     ${safeLocalizedText('config_userRule_itemsLocal_caption')}
+                     ${safeLocalizedText('config_userRule_itemsLocal_description')}</label>
               <textarea id=${safeAttrValue('userRule-ui-itemsLocal:' + id)}
                         class="userRule-ui-itemsLocal ${hiddenIfLocked(rule, 'itemsLocal')}"
                         placeholder=${safeLocalizedValue('config_userRule_itemsLocal_placeholder_' + matchTargetSuffix)}></textarea>

--- a/webextensions/options/options.html
+++ b/webextensions/options/options.html
@@ -39,6 +39,7 @@
                 class="array-type-config"
                 data-array-config-key="internalDomains"
                 placeholder="__MSG_config_internalDomains_input_placeholder__"></textarea>
+      <label>__MSG_config_internalDomains_input_description__</label>
     </fieldset>
 
     <p><label><input id="skipConfirmationForInternalMail" type="checkbox">__MSG_config_skipConfirmationForInternalMail_label__</label></p>

--- a/webextensions/test/test-matching-rules.js
+++ b/webextensions/test/test-matching-rules.js
@@ -1041,3 +1041,115 @@ export async function test_shouldHighlightBody() {
     { hasExternal: true, hasAttachment: true }
   ));
 }
+
+export async function test_shouldAcceptWildcardInRecipients() {
+  const matchingRules = new MatchingRules({
+    baseRules: [
+      { id:          'recipients',
+        enabled:     true,
+        matchTarget: Constants.MATCH_TO_RECIPIENT_DOMAIN,
+        highlight:   Constants.HIGHLIGHT_ALWAYS,
+        itemsSource: Constants.SOURCE_LOCAL_CONFIG,
+        itemsLocal:  ['*.example.com', '?.example.org'] },
+    ],
+  });
+  await matchingRules.populate();
+
+  is(
+    [
+      'user@.example.com',
+      'user@X.example.com',
+      'user@XX.example.com',
+      'user@X.example.org',
+    ],
+    matchingRules.getHighlightedRecipientAddresses({
+      externals:   [
+        'user@.example.com',
+        'user@X.example.com',
+        'user@XX.example.com',
+        'user@.example.org',
+        'user@X.example.org',
+        'user@XX.example.org',
+      ],
+      attachments: [],
+    })
+  );
+}
+
+export async function test_shouldAcceptWildcardForAttachments() {
+  const matchingRules = new MatchingRules({
+    baseRules: [
+      { id:          'filename',
+        enabled:     true,
+        matchTarget: Constants.MATCH_TO_ATTACHMENT_NAME,
+        highlight:   Constants.HIGHLIGHT_ALWAYS,
+        itemsSource: Constants.SOURCE_LOCAL_CONFIG,
+        itemsLocal:  ['astarisk*name', 'question?name'] },
+      { id:          'filesuffix',
+        enabled:     true,
+        matchTarget: Constants.MATCH_TO_ATTACHMENT_SUFFIX,
+        highlight:   Constants.HIGHLIGHT_ALWAYS,
+        itemsSource: Constants.SOURCE_LOCAL_CONFIG,
+        itemsLocal:  ['.astarisk*suffix', '.question?suffix'] },
+    ],
+  });
+  await matchingRules.populate();
+  is(
+    {
+      'filename': [
+        'astariskname1.ext',
+        'astariskXname2.ext',
+        'astariskXXname2.ext',
+        'questionXname2.ext',
+      ],
+      'filesuffix': [
+        'basename1.astarisksuffix',
+        'basename2.astariskXsuffix',
+        'basename3.astariskXXsuffix',
+        'basename2.questionXsuffix',
+      ],
+    },
+    attachmentsToNames(matchingRules.classifyBlockAttachments({
+      attachments: [
+        'astariskname1.ext',
+        'astariskXname2.ext',
+        'astariskXXname2.ext',
+        'questionname1.ext',
+        'questionXname2.ext',
+        'questionXXname2.ext',
+        'basename1.astarisksuffix',
+        'basename2.astariskXsuffix',
+        'basename3.astariskXXsuffix',
+        'basename1.questionsuffix',
+        'basename2.questionXsuffix',
+        'basename3.questionXXsuffix',
+      ],
+      hasExternal: false,
+    }))
+  );
+}
+
+export async function test_shouldAcceptWildcardInBody() {
+  const matchingRules = new MatchingRules({
+    baseRules: [
+      { id:          'body',
+        enabled:     true,
+        matchTarget: Constants.MATCH_TO_BODY,
+        highlight:   Constants.HIGHLIGHT_ALWAYS,
+        itemsSource: Constants.SOURCE_LOCAL_CONFIG,
+        itemsLocal:  ['body*with*astarisk', 'body?with?question'] },
+    ],
+  });
+  await matchingRules.populate();
+  is(
+    [
+      'bodywithastarisk',
+      'body with astarisk',
+      'body  with  astarisk',
+      'bodywithaquestion',
+      'body with question',
+      'body  with  question',
+    ],
+    [].map(body => matchingRules.shouldHighlightBody(body))
+  );
+}

--- a/webextensions/test/test-matching-rules.js
+++ b/webextensions/test/test-matching-rules.js
@@ -1055,7 +1055,6 @@ export async function test_shouldAcceptWildcardInRecipients() {
   });
   await matchingRules.populate();
 
-console.log('matchingRules.$matchedDomainSets ', matchingRules.$matchedDomainSets);
   is(
     [
       'user@.example.com',
@@ -1063,7 +1062,7 @@ console.log('matchingRules.$matchedDomainSets ', matchingRules.$matchedDomainSet
       'user@XX.example.com',
       'user@X.example.org',
     ],
-    matchingRules.getHighlightedRecipientAddresses({
+    [...matchingRules.getHighlightedRecipientAddresses({
       externals:   [
         'user@.example.com',
         'user@X.example.com',
@@ -1073,7 +1072,7 @@ console.log('matchingRules.$matchedDomainSets ', matchingRules.$matchedDomainSet
         'user@XX.example.org',
       ],
       attachments: [],
-    })
+    })]
   );
 }
 
@@ -1096,23 +1095,18 @@ export async function test_shouldAcceptWildcardForAttachments() {
   });
   await matchingRules.populate();
 
-console.log('matchingRules.$attachmentMatchers ', matchingRules.$attachmentMatchers);
   is(
-    {
-      'filename': [
-        'astariskname1.ext',
-        'astariskXname2.ext',
-        'astariskXXname2.ext',
-        'questionXname2.ext',
-      ],
-      'filesuffix': [
-        'basename1.astarisksuffix',
-        'basename2.astariskXsuffix',
-        'basename3.astariskXXsuffix',
-        'basename2.questionXsuffix',
-      ],
-    },
-    attachmentsToNames(matchingRules.classifyBlockAttachments({
+    [
+      'astariskname1.ext',
+      'astariskXname2.ext',
+      'astariskXXname2.ext',
+      'questionXname2.ext',
+      'basename1.astarisksuffix',
+      'basename2.astariskXsuffix',
+      'basename3.astariskXXsuffix',
+      'basename2.questionXsuffix',
+    ],
+    [...matchingRules.getHighlightedAttachmentNames({
       attachments: [
         'astariskname1.ext',
         'astariskXname2.ext',
@@ -1126,9 +1120,9 @@ console.log('matchingRules.$attachmentMatchers ', matchingRules.$attachmentMatch
         'basename1.questionsuffix',
         'basename2.questionXsuffix',
         'basename3.questionXXsuffix',
-      ],
+      ].map(name => ({ name })),
       hasExternal: false,
-    }))
+    })]
   );
 }
 
@@ -1145,8 +1139,13 @@ export async function test_shouldAcceptWildcardInBody() {
   });
   await matchingRules.populate();
 
-console.log('matchingRules.$bodyMatchers ', matchingRules.$bodyMatchers);
   is(
+    [
+      'bodywithastarisk',
+      'body with astarisk',
+      'body  with  astarisk',
+      'body with question',
+    ],
     [
       'bodywithastarisk',
       'body with astarisk',
@@ -1154,7 +1153,6 @@ console.log('matchingRules.$bodyMatchers ', matchingRules.$bodyMatchers);
       'bodywithaquestion',
       'body with question',
       'body  with  question',
-    ],
-    [].map(body => matchingRules.shouldHighlightBody(body))
+    ].filter(body => matchingRules.shouldHighlightBody(body))
   );
 }

--- a/webextensions/test/test-matching-rules.js
+++ b/webextensions/test/test-matching-rules.js
@@ -1055,6 +1055,7 @@ export async function test_shouldAcceptWildcardInRecipients() {
   });
   await matchingRules.populate();
 
+console.log('matchingRules.$matchedDomainSets ', matchingRules.$matchedDomainSets);
   is(
     [
       'user@.example.com',
@@ -1094,6 +1095,8 @@ export async function test_shouldAcceptWildcardForAttachments() {
     ],
   });
   await matchingRules.populate();
+
+console.log('matchingRules.$attachmentMatchers ', matchingRules.$attachmentMatchers);
   is(
     {
       'filename': [
@@ -1141,6 +1144,8 @@ export async function test_shouldAcceptWildcardInBody() {
     ],
   });
   await matchingRules.populate();
+
+console.log('matchingRules.$bodyMatchers ', matchingRules.$bodyMatchers);
   is(
     [
       'bodywithastarisk',

--- a/webextensions/test/test-recipient-classifier.js
+++ b/webextensions/test/test-recipient-classifier.js
@@ -222,6 +222,32 @@ test_classifyAddresses.parameters = {
       ],
     }
   },
+  'support wildcards': {
+    recipients: [
+      'aaa@.example.com',
+      'aaa@X.example.com',
+      'aaa@XX.example.com',
+      'bbb@.example.net',
+      'bbb@X.example.net',
+      'bbb@XX.example.net',
+    ],
+    internalDomains: [
+      '*.example.com',
+      '?.example.net',
+    ],
+    expected: {
+      internals: [
+        'aaa@.example.com',
+        'aaa@X.example.com',
+        'aaa@XX.example.com',
+        'bbb@X.example.net',
+      ],
+      externals: [
+        'bbb@.example.net',
+        'bbb@XX.example.net',
+      ],
+    }
+  },
 };
 export function test_classifyAddresses({ recipients, internalDomains, expected }) {
   const classifier = new RecipientClassifier({ internalDomains });


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

This change will make FlexConfirmMail supporting wildcards in domains and terms.

# How to verify the fixed issue:

Try to use domains and terms with wildcards.

## The steps to verify:

1. Build the XPI.
2. Install XPI to your Thunderbird.
3. Setup FlexConfirmMail as:
   * internal domains: `*.example.com`
   * specially confirmed external domains: `*.example.org`
   * specially confirmed terms for attachments: `set*up`
4. Prepare a text file with filename `set-up.txt`
5. Start composition
6. Set recipients: `example@internal.example.com`, `example@group.example.com`, `example@dangerous.example.org` and `example@fake.example.org`
7. Attach the file `set-up.txt`
8. Try to send the message

## Expected result:

* All `*.example.com` recipients should be detected as internal domains
* All `*.example.org` recipients should be detected as specially confirmed domains
* The attachment should be confirmed specially.
