### PR TITLE
Bump version to 4.1.7

### DIFF
--- a/webextensions/manifest.json
+++ b/webextensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "author": "ClearCode Inc.",
   "description": "__MSG_extensionDescription__",
   "permissions": [

--- a/webextensions/native-messaging-host/host.go
+++ b/webextensions/native-messaging-host/host.go
@@ -19,7 +19,7 @@ import (
 	"time"
 )
 
-const VERSION = "4.1.6";
+const VERSION = "4.1.7";
 
 
 var RunInCLI bool


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

This just bumps the version number to 4.1.7 from 4.1.6.

# How to verify the fixed issue:

Build it and confirm versions are incremented.

## The steps to verify:

1. Cd to `webextensions`.
2. Run `make` to build XPI.
3. Run `make host` to build the native messaging host.
4. Install XPI to Thunderbird and confirm its version.
5. Start `cmd.exe` on Windows and run `webextensions/native-messaging-host/amd64/host.exe` (on Windows 64bit) with an option `-v` to confirm the reported version.

## Expected result:

Both versions are 4.1.7.
