### PR TITLE
Output more debuggable log around countdown feature

### DIFF
--- a/webextensions/background/background.js
+++ b/webextensions/background/background.js
@@ -21,8 +21,6 @@ import { RecipientClassifier } from '/common/recipient-classifier.js';
 
 import * as ListUtils from './list-utils.js';
 
-Dialog.setLogger(log);
-
 const TYPE_NEWLY_COMPOSED   = 'new-message';
 const TYPE_REPLY            = 'reply';
 const TYPE_DRAFT            = 'draft';

--- a/webextensions/common/common.js
+++ b/webextensions/common/common.js
@@ -7,6 +7,7 @@
 
 import Configs from '/extlib/Configs.js';
 import * as Constants from './constants.js';
+import * as Dialog from '/extlib/dialog.js';
 
 const OVERRIDE_DEFAULT_CONFIGS = {}; /* Replace this for more customization on an enterprise use. */
 
@@ -258,8 +259,11 @@ export function log(message, ...args) {
   for (let i = 0; i < nest; i++) {
     indent += ' ';
   }
-  console.log(`flex-confirm-mail: ${indent}${message}`, ...args);
+  const timestamp = new Date().toLocaleString();
+  console.log(`${timestamp} flex-confirm-mail: ${indent}${message}`, ...args);
 }
+
+Dialog.setLogger(log);
 
 export async function sendToHost(message) {
   try {

--- a/webextensions/dialog/countdown/countdown.js
+++ b/webextensions/dialog/countdown/countdown.js
@@ -9,7 +9,8 @@ import '/extlib/l10n.js';
 import * as Dialog from '/extlib/dialog.js';
 
 import {
-  configs
+  configs,
+  log,
 } from '/common/common.js';
 
 const mCounter = document.getElementById('count');
@@ -41,10 +42,18 @@ configs.$loaded.then(async () => {
   });
 
   const start = Date.now();
-  window.setInterval(() => {
+  const timer = window.setInterval(() => {
     const rest = Math.ceil(configs.countdownSeconds - ((Date.now() - start) / 1000));
     mCounter.textContent = rest;
-    if (rest <= 0)
+    if (rest > 0)
+      return;
+    window.clearInterval(timer);
+    try {
       Dialog.accept();
+    }
+    catch(error) {
+      log('failed to accept countdown dialog: ', error);
+      window.close();
+    }
   }, 250);
 });

--- a/webextensions/dialog/countdown/countdown.js
+++ b/webextensions/dialog/countdown/countdown.js
@@ -53,7 +53,7 @@ configs.$loaded.then(async () => {
     }
     catch(error) {
       log('failed to accept countdown dialog: ', error);
-      window.close();
+      //window.close();
     }
   }, 250);
 });

--- a/webextensions/dialog/countdown/countdown.js
+++ b/webextensions/dialog/countdown/countdown.js
@@ -53,7 +53,6 @@ configs.$loaded.then(async () => {
     }
     catch(error) {
       log('failed to accept countdown dialog: ', error);
-      //window.close();
     }
   }, 250);
 });


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Sometimes the countdown feature fails to close the dialog it self and shows negative counts.
This change adds codes to output more logs around the feature and introduces failsafe on such case.


# How to verify the fixed issue:

Try sending mail with countdown.

## The steps to verify:

1. Install.
2. Configure to show countdown and activate the debug mode.
3. Open debugger console for this addon.
4. Try to send a message.

## Expected result:

* Detailed logs are reported in the debugger console.
* Message is sent when the count become zero as expected.