### PR TITLE
Alert for added new domain

### DIFF
--- a/webextensions/_locales/en/messages.json
+++ b/webextensions/_locales/en/messages.json
@@ -106,6 +106,7 @@
   "config_minConfirmMultipleRecipientDomainsCount_label_after": { "message": "or more domains in To/Cc recipients" },
   "config_allowCheckAllInternals_label": { "message": "Allow to make all internal recipients to be checked with one checkbox" },
   "config_allowCheckAllExternals_label": { "message": "Allow to make all external recipients to be checked with one checkbox" },
+  "config_emphasizeNewDomainRecipients_label": { "message": "Emphasize added recipients with domains different from any existing recipients" },
 
 
   "config_userRules_caption":              { "message": "More Rules" },

--- a/webextensions/_locales/en/messages.json
+++ b/webextensions/_locales/en/messages.json
@@ -23,6 +23,14 @@
   "confirmMultipleRecipientDomainsAccept": { "message": "Send" },
   "confirmMultipleRecipientDomainsCancel": { "message": "Cancel" },
 
+  "confirmNewDomainRecipientsDialogTitle": { "message": "Recipients with domains not included in the recipients of the original message" },
+  "confirmNewDomainRecipientsDialogMessage": { "message": "There are recipients with domains not included in the recipients of the original message.\n\n$RECIPIENTS$\n\nDo you really want to send this message?",
+    "placeholders": {
+      "domains": { "content": "$1", "example": "user@example.com" }
+    }},
+  "confirmNewDomainRecipientsAccept": { "message": "Send" },
+  "confirmNewDomainRecipientsCancel": { "message": "Cancel" },
+
 
   "confirmAttentionDomainsTitle": { "message": "Recipients with attention domains" },
   "confirmAttentionDomainsMessage": { "message": "These recipients with attention domains are found:\n\n$RECIPIENTS$\n\nIf there is no problem, continue to send.",
@@ -106,6 +114,7 @@
   "config_minConfirmMultipleRecipientDomainsCount_label_after": { "message": "or more domains in To/Cc recipients" },
   "config_allowCheckAllInternals_label": { "message": "Allow to make all internal recipients to be checked with one checkbox" },
   "config_allowCheckAllExternals_label": { "message": "Allow to make all external recipients to be checked with one checkbox" },
+  "config_confirmNewDomainRecipients_label": { "message": "Confirm when any recipients with domains different from any existing recipients are added" },
   "config_emphasizeNewDomainRecipients_label": { "message": "Emphasize added recipients with domains different from any existing recipients" },
 
 

--- a/webextensions/_locales/ja/messages.json
+++ b/webextensions/_locales/ja/messages.json
@@ -23,6 +23,14 @@
   "confirmMultipleRecipientDomainsAccept": { "message": "送信" },
   "confirmMultipleRecipientDomainsCancel": { "message": "キャンセル" },
 
+  "confirmNewDomainRecipientsDialogTitle": { "message": "返信元のメールの宛先に含まれていなかったドメインの宛先が追加されています" },
+  "confirmNewDomainRecipientsDialogMessage": { "message": "返信元のメールの宛先に含まれていなかったドメインの以下の宛先が追加されています。\n\n$RECIPIENTS$\n\n送信してよろしいですか？",
+    "placeholders": {
+      "recipients": { "content": "$1", "example": "user@example.com" }
+    }},
+  "confirmNewDomainRecipientsAccept": { "message": "送信" },
+  "confirmNewDomainRecipientsCancel": { "message": "キャンセル" },
+
 
   "confirmAttentionDomainsTitle": { "message": "特別に注意が必要な宛先" },
   "confirmAttentionDomainsMessage": { "message": "特別に注意が必要なドメインに属する以下の宛先があります。\n\n$RECIPIENTS$\n\n問題がない事を確認の上でメールを送信してください。",
@@ -106,6 +114,7 @@
   "config_minConfirmMultipleRecipientDomainsCount_label_after": { "message": "個以上のドメインが含まれる場合に警告する" },
   "config_allowCheckAllInternals_label": { "message": "組織内の宛先の一括チェックを許可" },
   "config_allowCheckAllExternals_label": { "message": "外部の宛先の一括チェックを許可" },
+  "config_confirmNewDomainRecipients_label": { "message": "返信の宛先に今まで含まれていなかったドメインのアドレスが追加された場合に警告する" },
   "config_emphasizeNewDomainRecipients_label": { "message": "返信の宛先に今まで含まれていなかったドメインのアドレスを強調表示する" },
 
 

--- a/webextensions/_locales/ja/messages.json
+++ b/webextensions/_locales/ja/messages.json
@@ -106,6 +106,7 @@
   "config_minConfirmMultipleRecipientDomainsCount_label_after": { "message": "個以上のドメインが含まれる場合に警告する" },
   "config_allowCheckAllInternals_label": { "message": "組織内の宛先の一括チェックを許可" },
   "config_allowCheckAllExternals_label": { "message": "外部の宛先の一括チェックを許可" },
+  "config_emphasizeNewDomainRecipients_label": { "message": "返信の宛先に今まで含まれていなかったドメインのアドレスを強調表示する" },
 
 
   "config_userRules_caption":              { "message": "追加のルール" },

--- a/webextensions/background/background.js
+++ b/webextensions/background/background.js
@@ -18,6 +18,7 @@ import {
 import * as Constants from '/common/constants.js';
 import { MatchingRules } from '/common/matching-rules.js';
 import { RecipientClassifier } from '/common/recipient-classifier.js';
+import * as RecipientParser from '/common/recipient-parser.js';
 
 import * as ListUtils from './list-utils.js';
 
@@ -44,6 +45,7 @@ function getMessageSignature(message) {
 // so we now wait for a message from a new composition content.
 const mDetectedMessageTypeForTab = new Map();
 const mDetectedClipboardStateForTab = new Map();
+const mInitialRecipientsForTab = new Map();
 const mInitialSignatureForTab = new Map();
 const mInitialSignatureForTabWithoutSubject = new Map();
 const mLastContextMessagesForTab = new Map();
@@ -53,6 +55,12 @@ browser.runtime.onMessage.addListener((message, sender) => {
       log('TYPE_COMPOSE_STARTED received ', message, sender);
       browser.compose.getComposeDetails(sender.tab.id).then(async details => {
         const author = await getAddressFromIdentity(details.identityId);
+        mInitialRecipientsForTab.set(sender.tab.id, [...new Set([
+          message.from || message.author,
+          ...(message.to || message.recipients || []),
+          ...(message.cc || message.ccList || []),
+          ...(message.bcc || message.bccList || []),
+        ])]);
         const signature = getMessageSignature({
           author,
           ...details
@@ -304,6 +312,15 @@ async function tryConfirm(tab, details, opener) {
     return;
   }
 
+  const initialRecipientDomains = [...new Set(mInitialRecipientsForTab.get(tab.id).map(recipient => RecipientParser.parse(recipient).domain))];
+  const newRecipientDomains = new Set();
+  for (const recipient of [...to, ...cc, ...bcc]) {
+    const domain = RecipientParser.parse(recipient).domain;
+    if (initialRecipientDomains.has(domain))
+      continue;
+    newRecipientDomains.add(domain);
+  }
+
   log('show confirmation ', tab, details);
 
   const dialogParams = {
@@ -336,6 +353,7 @@ async function tryConfirm(tab, details, opener) {
       internals: Array.from(internals),
       externals: Array.from(externals),
       attachments: details.attachments || await browser.compose.listAttachments(tab.id),
+      newRecipientDomains: [...newRecipientDomains],
     }
   );
 }
@@ -438,6 +456,7 @@ browser.compose.onBeforeSend.addListener(async (tab, details) => {
 
   log('confirmed: OK to send');
   mDetectedMessageTypeForTab.delete(tab.id)
+  mInitialRecipientsForTab.delete(tab.id);
   mInitialSignatureForTab.delete(tab.id);
   mInitialSignatureForTabWithoutSubject.delete(tab.id);
   mRecentlySavedDraftSignatures.clear();

--- a/webextensions/common/common.js
+++ b/webextensions/common/common.js
@@ -204,6 +204,7 @@ export const configs = new Configs({
   emphasizeTopMessage: false,
   topMessage: '',
   emphasizeRecipientType: false,
+  emphasizeNewDomainRecipients: true,
 
   showCountdown: false,
   countdownSeconds: 5,

--- a/webextensions/common/common.js
+++ b/webextensions/common/common.js
@@ -189,6 +189,9 @@ export const configs = new Configs({
   minConfirmationRecipientsCount: 0,
   confirmMultipleRecipientDomainsDialogTitle: '',
   confirmMultipleRecipientDomainsDialogMessage: '',
+  confirmNewDomainRecipients: false,
+  confirmNewDomainRecipientsDialogTitle: '',
+  confirmNewDomainRecipientsDialogMessage: '',
 
   allowCheckAllInternals: true,
   allowCheckAllExternals: false,

--- a/webextensions/dialog/confirm/confirm.js
+++ b/webextensions/dialog/confirm/confirm.js
@@ -24,6 +24,7 @@ let mParams;
 let mMatchingRules;
 let mBodyText;
 let mBodyHTML;
+let mNewRecipientDomains;
 
 let mTopMessage;
 let mInternalsAllCheck;
@@ -150,6 +151,8 @@ configs.$loaded.then(async () => {
   onConfigChange('topMessage');
   onConfigChange('debug');
 
+  mNewRecipientDomains = new Set(mParams.newRecipientDomains);
+
   initInternals();
   initExternals();
   initSubjectBlock();
@@ -248,7 +251,8 @@ function initExternals() {
       attachments: mParams.attachments,
     });
     const domainRow = createDomainRow(domain);
-    if (recipients.some(recipient => highlightedAddresses.has(recipient.address)))
+    if (recipients.some(recipient => highlightedAddresses.has(recipient.address)) ||
+        (configs.emphasizeNewDomainRecipients && mNewRecipientDomains.has(domain)))
       domainRow.classList.add('attention');
     mExternalsList.appendChild(domainRow);
 
@@ -257,7 +261,8 @@ function initExternals() {
       const row = createRecipientRow(recipient);
       row.dataset.domain = domain;
       row.classList.add(domainClass);
-      if (highlightedAddresses.has(recipient.address))
+      if (highlightedAddresses.has(recipient.address) ||
+          (configs.emphasizeNewDomainRecipients && mNewRecipientDomains.has(recipient.domain)))
         row.classList.add('attention');
       mExternalsList.appendChild(row);
     }

--- a/webextensions/manifest.json
+++ b/webextensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "4.1.7",
+  "version": "4.2.0",
   "author": "ClearCode Inc.",
   "description": "__MSG_extensionDescription__",
   "permissions": [

--- a/webextensions/options/options.html
+++ b/webextensions/options/options.html
@@ -50,6 +50,7 @@
              >__MSG_config_minConfirmMultipleRecipientDomainsCount_label_before__</label>
        <label><input id="minConfirmMultipleRecipientDomainsCount" type="number" size="4"
              >__MSG_config_minConfirmMultipleRecipientDomainsCount_label_after__</label></p>
+    <p><label><input id="confirmNewDomainRecipients" type="checkbox">__MSG_config_confirmNewDomainRecipients_label__</label></p>
 
     <hr class="spacer">
 

--- a/webextensions/options/options.html
+++ b/webextensions/options/options.html
@@ -98,6 +98,7 @@
               <input id="topMessage" type="text"></label></p>
     <p class="sub"><label><input id="emphasizeTopMessage" type="checkbox">__MSG_config_emphasizeTopMessage_label__</label></p>
     <p><label><input id="emphasizeRecipientType" type="checkbox">__MSG_config_emphasizeRecipientType_label__</label></p>
+    <p><label><input id="emphasizeNewDomainRecipients" type="checkbox">__MSG_config_emphasizeNewDomainRecipients_label__</label></p>
     </section>
 
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Miss selection from auto-completed recipients can happen when a user tries to reply an existing message and adds new recipients manually.
It sometimes causes fatal mistake like "I hope to add another member to this conversation exclusive with companies A and B, but unexpectedly added a different recipient of a third company C who has an email address local part same to another member of A or B.
This PR introduces new confirmation option for such cases: when a composition is started as a reply to an existing message, this memorizes all domains of existing recipients. After composition and on sending, this compares domains of final recipients and shows extra confirmation if there is any new recipients with a domain different from memorized known domains. (Moreover, recipients matching to the condition can be highlighted.)


# How to verify the fixed issue:

Try to create and send a reply to any existing message and add new recipient with a domain different from all existing recipients.

## The steps to verify:

1. Go to options of this addon.
2. Turn checkboxes "Confirm when any recipients with domains different from any existing recipients are added" and "Emphasize added recipients with domains different from any existing recipients" on.
3. Prepare a message containing one or more recipients with email addresses of same domain.
4. Start composition of a reply to the message.
5. Add a new recipient with an email address of different domain.
6. Try to send  the reply to show the confirmation dialog.
7. Turn all checkboxes on and try to send.

## Expected result:

* The added recipient is highlighted with different color, different font weight.
* An extra confirmation dialog is shown about the added recipient. It contains the email address of the added recipient.