### PR TITLE
Emphasize extra confirmation dialog contents more

### DIFF
--- a/webextensions/_locales/en/messages.json
+++ b/webextensions/_locales/en/messages.json
@@ -16,7 +16,7 @@
 
 
   "confirmMultipleRecipientDomainsTitle": { "message": "Multiple recipient domains in To or Cc" },
-  "confirmMultipleRecipientDomainsMessage": { "message": "There are multiple recipient domains in To or Cc.\n\n$DOMAINS$\n\nAll recipients information will be disclosed to all other recipients. Do you really want to send this message?",
+  "confirmMultipleRecipientDomainsMessage": { "message": "There are multiple recipient domains in To or Cc.\n\n<strong>$DOMAINS$</strong>\n\nAll recipients information will be disclosed to all other recipients. Do you really want to send this message?",
     "placeholders": {
       "domains": { "content": "$1", "example": "example.com" }
     }},
@@ -24,7 +24,7 @@
   "confirmMultipleRecipientDomainsCancel": { "message": "Cancel" },
 
   "confirmNewDomainRecipientsDialogTitle": { "message": "Recipients with domains not included in the recipients of the original message" },
-  "confirmNewDomainRecipientsDialogMessage": { "message": "There are recipients with domains not included in the recipients of the original message.\n\n$RECIPIENTS$\n\nDo you really want to send this message?",
+  "confirmNewDomainRecipientsDialogMessage": { "message": "There are recipients with domains not included in the recipients of the original message.\n\n<strong>$RECIPIENTS$</strong>\n\nDo you really want to send this message?",
     "placeholders": {
       "domains": { "content": "$1", "example": "user@example.com" }
     }},
@@ -33,7 +33,7 @@
 
 
   "confirmAttentionDomainsTitle": { "message": "Recipients with attention domains" },
-  "confirmAttentionDomainsMessage": { "message": "These recipients with attention domains are found:\n\n$RECIPIENTS$\n\nIf there is no problem, continue to send.",
+  "confirmAttentionDomainsMessage": { "message": "These recipients with attention domains are found:\n\n<strong>$RECIPIENTS$</strong>\n\nIf there is no problem, continue to send.",
     "placeholders": {
       "recipients": { "content": "$1", "example": "mail@example.com" }
     }},
@@ -42,7 +42,7 @@
 
 
   "confirmAttentionSuffixesTitle": { "message": "Attachments with attention file types" },
-  "confirmAttentionSuffixesMessage": { "message": "These attachments with attention extensions are found:\n\n$ATTACHMENTS$\n\nIf there is no problem, continue to send.",
+  "confirmAttentionSuffixesMessage": { "message": "These attachments with attention extensions are found:\n\n<strong>$ATTACHMENTS$</strong>\n\nIf there is no problem, continue to send.",
     "placeholders": {
       "attachments": { "content": "$1", "example": "file.txt" }
     }},
@@ -50,7 +50,7 @@
   "confirmAttentionSuffixesCancel": { "message": "Cancel" },
 
   "confirmAttentionSuffixes2Title": { "message": "Attachments with more attention file types" },
-  "confirmAttentionSuffixes2Message": { "message": "These attachments with more attention extensions are found:\n\n$ATTACHMENTS$\n\nIf there is no problem, continue to send.",
+  "confirmAttentionSuffixes2Message": { "message": "These attachments with more attention extensions are found:\n\n<strong>$ATTACHMENTS$</strong>\n\nIf there is no problem, continue to send.",
     "placeholders": {
       "attachments": { "content": "$1", "example": "file.txt" }
     }},
@@ -68,7 +68,7 @@
 
 
   "alertBlockedDomainsTitle": { "message": "Recipients with blocked domains" },
-  "alertBlockedDomainsMessage": { "message": "These recipients with blocked domains are found:\n\n$RECIPIENTS$\n\nIt is not allowe to send messages to such recipients.",
+  "alertBlockedDomainsMessage": { "message": "These recipients with blocked domains are found:\n\n<strong>$RECIPIENTS$</strong>\n\nIt is not allowe to send messages to such recipients.",
     "placeholders": {
       "recipients": { "content": "$1", "example": "mail@example.com" }
     }},

--- a/webextensions/_locales/ja/messages.json
+++ b/webextensions/_locales/ja/messages.json
@@ -16,7 +16,7 @@
 
 
   "confirmMultipleRecipientDomainsTitle": { "message": "複数のドメインがToまたはCcの宛先に含まれています" },
-  "confirmMultipleRecipientDomainsMessage": { "message": "ToまたはCcの宛先に複数のドメインが含まれています。\n\n$DOMAINS$\n\n送信すると、他の宛先の情報が全ての宛先に通知されます。送信してよろしいですか？",
+  "confirmMultipleRecipientDomainsMessage": { "message": "ToまたはCcの宛先に複数のドメインが含まれています。\n\n<strong>$DOMAINS$</strong>\n\n送信すると、他の宛先の情報が全ての宛先に通知されます。送信してよろしいですか？",
     "placeholders": {
       "domains": { "content": "$1", "example": "example.com" }
     }},
@@ -24,7 +24,7 @@
   "confirmMultipleRecipientDomainsCancel": { "message": "キャンセル" },
 
   "confirmNewDomainRecipientsDialogTitle": { "message": "返信元のメールの宛先に含まれていなかったドメインの宛先が追加されています" },
-  "confirmNewDomainRecipientsDialogMessage": { "message": "返信元のメールの宛先に含まれていなかったドメインの以下の宛先が追加されています。\n\n$RECIPIENTS$\n\n送信してよろしいですか？",
+  "confirmNewDomainRecipientsDialogMessage": { "message": "返信元のメールの宛先に含まれていなかったドメインの以下の宛先が追加されています。\n\n<strong>$RECIPIENTS$</strong>\n\n送信してよろしいですか？",
     "placeholders": {
       "recipients": { "content": "$1", "example": "user@example.com" }
     }},
@@ -33,7 +33,7 @@
 
 
   "confirmAttentionDomainsTitle": { "message": "特別に注意が必要な宛先" },
-  "confirmAttentionDomainsMessage": { "message": "特別に注意が必要なドメインに属する以下の宛先があります。\n\n$RECIPIENTS$\n\n問題がない事を確認の上でメールを送信してください。",
+  "confirmAttentionDomainsMessage": { "message": "特別に注意が必要なドメインに属する以下の宛先があります。\n\n<strong>$RECIPIENTS$</strong>\n\n問題がない事を確認の上でメールを送信してください。",
     "placeholders": {
       "recipients": { "content": "$1", "example": "mail@example.com" }
     }},
@@ -42,7 +42,7 @@
 
 
   "confirmAttentionSuffixesTitle": { "message": "特別に注意が必要な種類の添付ファイル" },
-  "confirmAttentionSuffixesMessage": { "message": "特別に注意が必要な拡張子を持つ以下の添付ファイルがあります。\n\n$ATTACHMENTS$\n\n問題がない事を確認の上でメールを送信してください。",
+  "confirmAttentionSuffixesMessage": { "message": "特別に注意が必要な拡張子を持つ以下の添付ファイルがあります。\n\n<strong>$ATTACHMENTS$</strong>\n\n問題がない事を確認の上でメールを送信してください。",
     "placeholders": {
       "attachments": { "content": "$1", "example": "file.txt" }
     }},
@@ -50,7 +50,7 @@
   "confirmAttentionSuffixesCancel": { "message": "キャンセル" },
 
   "confirmAttentionSuffixes2Title": { "message": "さらに特別に注意が必要な種類の添付ファイル" },
-  "confirmAttentionSuffixes2Message": { "message": "さらに特別に注意が必要な拡張子を持つ以下の添付ファイルがあります。\n\n$ATTACHMENTS$\n\n問題がない事を確認の上でメールを送信してください。",
+  "confirmAttentionSuffixes2Message": { "message": "さらに特別に注意が必要な拡張子を持つ以下の添付ファイルがあります。\n\n<strong>$ATTACHMENTS$</strong>\n\n問題がない事を確認の上でメールを送信してください。",
     "placeholders": {
       "attachments": { "content": "$1", "example": "file.txt" }
     }},
@@ -59,7 +59,7 @@
 
 
   "confirmAttentionTermsTitle": { "message": "特別に注意が必要な名前の添付ファイル" },
-  "confirmAttentionTermsMessage": { "message": "特別に注意が必要な語句を名前に含む以下の添付ファイルがあります。\n\n$ATTACHMENTS$\n\n問題がない事を確認の上でメールを送信してください。",
+  "confirmAttentionTermsMessage": { "message": "特別に注意が必要な語句を名前に含む以下の添付ファイルがあります。\n\n<strong>$ATTACHMENTS$</strong>\n\n問題がない事を確認の上でメールを送信してください。",
     "placeholders": {
       "attachments": { "content": "$1", "example": "file.txt" }
     }},
@@ -68,7 +68,7 @@
 
 
   "alertBlockedDomainsTitle": { "message": "ブロック対象の宛先" },
-  "alertBlockedDomainsMessage": { "message": "ブロック対象のドメインに属する以下の宛先があります。\n\n$RECIPIENTS$\n\nこれらの宛先にメールを送ることはできません。",
+  "alertBlockedDomainsMessage": { "message": "ブロック対象のドメインに属する以下の宛先があります。\n\n<strong>$RECIPIENTS$</strong>\n\nこれらの宛先にメールを送ることはできません。",
     "placeholders": {
       "recipients": { "content": "$1", "example": "mail@example.com" }
     }},

--- a/webextensions/_locales/zh_CN/messages.json
+++ b/webextensions/_locales/zh_CN/messages.json
@@ -16,7 +16,7 @@
 
 
   "confirmMultipleRecipientDomainsTitle": { "message": "多个域被包含在收件人或抄送目的地中" },
-  "confirmMultipleRecipientDomainsMessage": { "message": "收件人或抄送目的地包含一个以上的域。\n\n$DOMAINS$\n\n一旦发送，所有其他目的地将被告知。 你确定你要发送这个吗？",
+  "confirmMultipleRecipientDomainsMessage": { "message": "收件人或抄送目的地包含一个以上的域。\n\n<strong>$DOMAINS$</strong>\n\n一旦发送，所有其他目的地将被告知。 你确定你要发送这个吗？",
     "placeholders": {
       "domains": { "content": "$1", "example": "example.com" }
     }},
@@ -25,7 +25,7 @@
 
 
   "confirmAttentionDomainsTitle": { "message": "需要特别注意的目的地" },
-  "confirmAttentionDomainsMessage": { "message": "以下目的地属于需要特别注意的领域。\n\n$RECIPIENTS$\n\n请在发送邮件前确认一切正常。",
+  "confirmAttentionDomainsMessage": { "message": "以下目的地属于需要特别注意的领域。\n\n<strong>$RECIPIENTS$</strong>\n\n请在发送邮件前确认一切正常。",
     "placeholders": {
       "recipients": { "content": "$1", "example": "mail@example.com" }
     }},
@@ -34,7 +34,7 @@
 
 
   "confirmAttentionSuffixesTitle": { "message": "需要特别注意的附件类型" },
-  "confirmAttentionSuffixesMessage": { "message": "以下是需要特别注意的带有扩展的附件。\n\n$ATTACHMENTS$\n\n请在发送邮件前确认一切正常。",
+  "confirmAttentionSuffixesMessage": { "message": "以下是需要特别注意的带有扩展的附件。\n\n<strong>$ATTACHMENTS$</strong>\n\n请在发送邮件前确认一切正常。",
     "placeholders": {
       "attachments": { "content": "$1", "example": "file.txt" }
     }},
@@ -42,7 +42,7 @@
   "confirmAttentionSuffixesCancel": { "message": "取消" },
 
   "confirmAttentionSuffixes2Title": { "message": "需要特别注意的其他类型的附件" },
-  "confirmAttentionSuffixes2Message": { "message": "此外，还有以下带有扩展的附件需要特别注意。\n\n$ATTACHMENTS$\n\n请在发送邮件前确认一切正常。",
+  "confirmAttentionSuffixes2Message": { "message": "此外，还有以下带有扩展的附件需要特别注意。\n\n<strong>$ATTACHMENTS$</strong>\n\n请在发送邮件前确认一切正常。",
     "placeholders": {
       "attachments": { "content": "$1", "example": "file.txt" }
     }},
@@ -51,7 +51,7 @@
 
 
   "confirmAttentionTermsTitle": { "message": "命名需要特别注意的附件" },
-  "confirmAttentionTermsMessage": { "message": "以下附件的名称中含有需要特别注意的单词或短语。\n\n$ATTACHMENTS$\n\n请在发送邮件前确认一切正常。",
+  "confirmAttentionTermsMessage": { "message": "以下附件的名称中含有需要特别注意的单词或短语。\n\n<strong>$ATTACHMENTS$</strong>\n\n请在发送邮件前确认一切正常。",
     "placeholders": {
       "attachments": { "content": "$1", "example": "file.txt" }
     }},
@@ -60,7 +60,7 @@
 
 
   "alertBlockedDomainsTitle": { "message": "将被封锁的目的地" },
-  "alertBlockedDomainsMessage": { "message": "以下目的地属于要被封锁的域。\n\n$RECIPIENTS$\n\n不可能向这些地址发送邮件。",
+  "alertBlockedDomainsMessage": { "message": "以下目的地属于要被封锁的域。\n\n<strong>$RECIPIENTS$</strong>\n\n不可能向这些地址发送邮件。",
     "placeholders": {
       "recipients": { "content": "$1", "example": "mail@example.com" }
     }},

--- a/webextensions/common/common.js
+++ b/webextensions/common/common.js
@@ -208,6 +208,36 @@ export const configs = new Configs({
   topMessage: '',
   emphasizeRecipientType: false,
   emphasizeNewDomainRecipients: true,
+  extraStyleRules: `
+/* Emphasize reconfirmation dialogs more */
+/*
+.rich-confirm-dialog {
+  background: red !important;
+  padding: 1.5em;
+}
+
+.rich-confirm-dialog::before {
+  color: white !important;
+  content: "CAUTION!!";
+  display: block;
+  font-size: x-large !important;
+  font-weight: bold !important;
+  position: relative;
+  text-align: center;
+  top: -0.5em;
+}
+
+.rich-confirm-content {
+  background: var(--bg-color) !important;
+  padding: 1em;
+}
+
+.rich-confirm-content strong {
+  font-size: large;
+  font-weight: bold;
+}
+*/
+  `.trim(),
 
   showCountdown: false,
   countdownSeconds: 5,
@@ -423,6 +453,13 @@ export async function applyOutlookGPOConfigs() {
   applyOutlookGPOConfig(response, 'fixedInternalDomains');
   applyOutlookGPOConfigRuleItems(response, 'builtInAttentionDomains');
   applyOutlookGPOConfigRuleItems(response, 'builtInAttentionTerms');
+}
+
+export function applyExtraStyleRules() {
+  const style = document.createElement('style');
+  style.setAttribute('type', 'text/css');
+  style.appendChild(document.createTextNode(configs.extraStyleRules || ''));
+  (document.head || document.body).appendChild(style);
 }
 
 

--- a/webextensions/dialog/confirm/confirm.js
+++ b/webextensions/dialog/confirm/confirm.js
@@ -464,7 +464,10 @@ async function confirmedMultipleRecipientDomains() {
       buttons: [
         browser.i18n.getMessage('confirmMultipleRecipientDomainsAccept'),
         browser.i18n.getMessage('confirmMultipleRecipientDomainsCancel')
-      ]
+      ],
+      onShown(content) {
+        content.closest('.rich-confirm-dialog').classList.add('for-multiple-recipient-domains');
+      },
     });
   }
   catch(_error) {
@@ -504,7 +507,10 @@ async function confirmedNewDomainRecipients() {
       buttons: [
         browser.i18n.getMessage('confirmNewDomainRecipientsAccept'),
         browser.i18n.getMessage('confirmNewDomainRecipientsCancel')
-      ]
+      ],
+      onShown(content) {
+        content.closest('.rich-confirm-dialog').classList.add('for-new-domain-recipients');
+      },
     });
   }
   catch(_error) {
@@ -527,7 +533,7 @@ async function confirmedWithRules() {
     attachments: mParams.attachments,
     subject:     mParams.details.subject,
     body:        mBodyText,
-    async confirm({ title, message }) {
+    async confirm({ title, message, rule }) {
       let result;
       try {
         result = await RichConfirm.show({
@@ -540,6 +546,9 @@ async function confirmedWithRules() {
             browser.i18n.getMessage('reconfirmAccept'),
             browser.i18n.getMessage('reconfirmCancel'),
           ],
+          onShown(content) {
+            content.closest('.rich-confirm-dialog').classList.add(`for-${rule.name.replace(/[\s\|:()\[\]<>{}!?*\.\/\\~+]/g, '_')}`);
+          },
         });
       }
       catch(_error) {

--- a/webextensions/dialog/confirm/confirm.js
+++ b/webextensions/dialog/confirm/confirm.js
@@ -14,6 +14,7 @@ import {
   log,
   toDOMDocumentFragment,
   readFile,
+  applyExtraStyleRules,
 } from '/common/common.js';
 import * as Constants from '/common/constants.js';
 
@@ -130,6 +131,7 @@ function buildFields() {
 }
 
 configs.$loaded.then(async () => {
+  applyExtraStyleRules();
   buildFields();
 
   mParams = await Dialog.getParams();

--- a/webextensions/dialog/confirm/confirm.js
+++ b/webextensions/dialog/confirm/confirm.js
@@ -458,7 +458,7 @@ async function confirmedMultipleRecipientDomains() {
       type:  'common-dialog',
       url:   '/resources/blank.html',
       title: configs.confirmMultipleRecipientDomainsDialogTitle || browser.i18n.getMessage('confirmMultipleRecipientDomainsTitle'),
-      message,
+      content: message,
       buttons: [
         browser.i18n.getMessage('confirmMultipleRecipientDomainsAccept'),
         browser.i18n.getMessage('confirmMultipleRecipientDomainsCancel')
@@ -498,7 +498,7 @@ async function confirmedNewDomainRecipients() {
       type:  'common-dialog',
       url:   '/resources/blank.html',
       title: configs.confirmNewDomainRecipientsDialogTitle || browser.i18n.getMessage('confirmNewDomainRecipientsDialogTitle'),
-      message,
+      content: message,
       buttons: [
         browser.i18n.getMessage('confirmNewDomainRecipientsAccept'),
         browser.i18n.getMessage('confirmNewDomainRecipientsCancel')
@@ -533,7 +533,7 @@ async function confirmedWithRules() {
           type:  'common-dialog',
           url:   '/resources/blank.html',
           title,
-          message,
+          content: message,
           buttons: [
             browser.i18n.getMessage('reconfirmAccept'),
             browser.i18n.getMessage('reconfirmCancel'),

--- a/webextensions/dialog/countdown/countdown.js
+++ b/webextensions/dialog/countdown/countdown.js
@@ -11,6 +11,7 @@ import * as Dialog from '/extlib/dialog.js';
 import {
   configs,
   log,
+  applyExtraStyleRules,
 } from '/common/common.js';
 
 const mCounter = document.getElementById('count');
@@ -18,6 +19,7 @@ const mSkipButton = document.getElementById('skip');
 const mCancelButton = document.getElementById('cancel');
 
 configs.$loaded.then(async () => {
+  applyExtraStyleRules();
   mCounter.textContent = configs.countdownSeconds;
 
   if (configs.countdownAllowSkip) {

--- a/webextensions/manifest.json
+++ b/webextensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "author": "ClearCode Inc.",
   "description": "__MSG_extensionDescription__",
   "permissions": [


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

The message of reconfirmation dialogs are currently very flat and it is not clear what we should check about.
With this change, embedded addresses, domains, and other important part is emphasized more, and we can apply more custom style rules to emphasize arbitrary dialog.

# How to verify the fixed issue:

Configure this addon to reconfirm some cases and see the actual dialog.

## The steps to verify:

1. Install this addon.
2. Go to the options page of this addon, and set options:
   * Recipients => Confirm when any recipients with domains different from any existing recipients are added (checked)
   * Development => All Configs => extraStyleRules: set as `.rich-confirm-dialog.for-new-domain-recipients { background: red !important; padding: 1.5em; }  .rich-confirm-dialog.for-new-domain-recipients::before { color: white !important; content: "CAUTION!"; display: block; font-size: x-large !important; font-weight: bold !important; position: relative; text-align: center; top: -0.5em; } .rich-confirm-dialog.for-new-domain-recipients .rich-confirm-content { background: var(--bg-color) !important; padding: 1em; } .rich-confirm-dialog.for-new-domain-recipients .rich-confirm-content strong { font-size: large; font-weight: bold; }`
3. Start to composite a reply for an received message.
4. Add new domain recipient like `test@example.com`.
5. Try sending it.

## Expected result:

A reconfirmation dialog is shown with customized appearance like as:
![image](https://github.com/FlexConfirmMail/Thunderbird/assets/70062/03042690-f8f6-4e7c-b309-e0d6e66fb483)
