### PR TITLE
Support matching to local part of recipients

### DIFF
--- a/webextensions/common/recipient-classifier.js
+++ b/webextensions/common/recipient-classifier.js
@@ -14,8 +14,8 @@ export class RecipientClassifier {
         .filter(pattern => !pattern.startsWith('#')) // reject commented out items
         .map(
           pattern => pattern.toLowerCase()
-            .replace(/^(-?)@/, '$1') // "@example.com" => "example.com"
-            .replace(/^(-?)(?![^@]+@)/, '$1?*@') // "example.com" => "?*@example.com"
+            .replace(/^(-?)@/, '$1') // delete needless "@" from domain only patterns: "@example.com" => "example.com"
+            .replace(/^(-?)(?![^@]+@)/, '$1*@') // normalize to full address patterns: "foo@example.com" => "foo@example.com", "example.com" => "*@example.com"
         )
     );
     const negativeItems = new Set(

--- a/webextensions/common/recipient-classifier.js
+++ b/webextensions/common/recipient-classifier.js
@@ -9,21 +9,25 @@ import * as RecipientParser from './recipient-parser.js';
 
 export class RecipientClassifier {
   constructor({ internalDomains } = {}) {
-    const uniqueDomains = new Set(
+    const uniquePatterns = new Set(
       (internalDomains || [])
-        .map(domain => domain.toLowerCase().replace(/^(-?)@/, '$1'))
-        .filter(domain => !domain.startsWith('#')) // reject commented out items
+        .filter(pattern => !pattern.startsWith('#')) // reject commented out items
+        .map(
+          pattern => pattern.toLowerCase()
+            .replace(/^(-?)@/, '$1') // "@example.com" => "example.com"
+            .replace(/^(-?)(?![^@]+@)/, '$1?*@') // "example.com" => "?*@example.com"
+        )
     );
     const negativeItems = new Set(
-      [...uniqueDomains]
-        .filter(domain => domain.startsWith('-'))
-        .map(domain => domain.replace(/^-/, ''))
+      [...uniquePatterns]
+        .filter(pattern => pattern.startsWith('-'))
+        .map(pattern => pattern.replace(/^-/, ''))
     );
     for (const negativeItem of negativeItems) {
-      uniqueDomains.delete(negativeItem);
-      uniqueDomains.delete(`-${negativeItem}`);
+      uniquePatterns.delete(negativeItem);
+      uniquePatterns.delete(`-${negativeItem}`);
     }
-    this.$internalDomainsMatcher = new RegExp(`^(${[...uniqueDomains].map(domain => this.$toRegExpSource(domain)).join('|')})$`, 'i');
+    this.$internalDomainsMatcher = new RegExp(`^(${[...uniquePatterns].map(pattern => this.$toRegExpSource(pattern)).join('|')})$`, 'i');
     this.classify = this.classify.bind(this);
   }
 
@@ -44,8 +48,8 @@ export class RecipientClassifier {
       const classifiedRecipient = {
         ...RecipientParser.parse(recipient),
       };
-      const domain = classifiedRecipient.domain;
-      if (this.$internalDomainsMatcher.test(domain))
+      const address = classifiedRecipient.address;
+      if (this.$internalDomainsMatcher.test(address))
         internals.add(classifiedRecipient);
       else
         externals.add(classifiedRecipient);

--- a/webextensions/test/test-recipient-classifier.js
+++ b/webextensions/test/test-recipient-classifier.js
@@ -248,6 +248,65 @@ test_classifyAddresses.parameters = {
       ],
     }
   },
+  'support local part': {
+    recipients: [
+      'aaa.xx@example.com',
+      'bbb.yy@example.com',
+      'ccc.zz@example.com',
+      'ddd@example.com',
+    ],
+    internalDomains: [
+      '*.xx@example.com',
+      '*.yy@example.com',
+    ],
+    expected: {
+      internals: [
+        'aaa.xx@example.com',
+        'bbb.yy@example.com',
+      ],
+      externals: [
+        'ccc.zz@example.com',
+        'ddd@example.com',
+      ],
+    }
+  },
+  'local part with negative modifier': {
+    recipients: [
+      'aaa.xx@example.com',
+      'bbb.xx@example.com',
+    ],
+    internalDomains: [
+      '*.xx@example.com',
+      '-*.xx@example.com',
+    ],
+    expected: {
+      internals: [
+      ],
+      externals: [
+        'aaa.xx@example.com',
+        'bbb.xx@example.com',
+      ],
+    }
+  },
+  'wildcards in both local part and domain part': {
+    recipients: [
+      'aaa.xx@foo.example.com',
+      'bbb.xx@bar.example.com',
+      'ccc.zz@bar.example.com',
+    ],
+    internalDomains: [
+      '*.xx@*example.com',
+    ],
+    expected: {
+      internals: [
+        'aaa.xx@foo.example.com',
+        'bbb.xx@bar.example.com',
+      ],
+      externals: [
+        'ccc.zz@bar.example.com',
+      ],
+    }
+  },
 };
 export function test_classifyAddresses({ recipients, internalDomains, expected }) {
   const classifier = new RecipientClassifier({ internalDomains });


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Currently this addon supports only matching with the domain part of recipients.
This PR adds support to define patterns containing local part.
You need to write patterns with local part with the special delimiter `@`, in other words, patterns without `@` are treated as just domain patterns for backward compatibility.

# How to verify the fixed issue:

Try to define patterns with local part and verify that matched recipients are detected as expected.

## The steps to verify:

1. Assume that you have a GMail account and `gmail.com` is not an internal domain.
2. Add a pattern with local part matching to your address to the list of internal domains. For example, if your address is `piro.outsider.reflex@gmail.com`, you should add `piro*@gmail.com`.
3. Compose a new message to multiple recipients including both internal and external domains.
4. Add your address matching to the pattern you've added, to the list of recipients.
5. Try to send the message.

## Expected result:

Your address matching to the pattern is detected as an internal domain recipient in the confirmation dialog.