### PR TITLE
Matching to local part on extra rules

### DIFF
--- a/webextensions/_locales/en/messages.json
+++ b/webextensions/_locales/en/messages.json
@@ -145,7 +145,7 @@
   "config_userRule_enabled_tooltiptext": { "message": "Check to activate this rule" },
 
   "config_userRule_matchTarget_caption":          { "message": "Match to:" },
-  "config_userRule_matchTarget_recipientDomain":  { "message": "Domain Name of Recipients" },
+  "config_userRule_matchTarget_recipientDomain":  { "message": "Address of Recipients" },
   "config_userRule_matchTarget_attachmentName":   { "message": "Attachment Names" },
   "config_userRule_matchTarget_attachmentSuffix": { "message": "Attachment Suffixes" },
   "config_userRule_matchTarget_subject":          { "message": "Subject" },
@@ -175,7 +175,7 @@
   "config_userRule_action_blockExternalsWithAttachments": { "message": "Disallow to send messages only when there is any external recipient and attachment" },
 
   "config_userRule_itemsLocal_caption":                      { "message": "Use a manually managed list" },
-  "config_userRule_itemsLocal_placeholder_recipientDomain":  { "message": "Input a domain name per line (e.g. example.com)" },
+  "config_userRule_itemsLocal_placeholder_recipientDomain":  { "message": "Input a domain name or address per line (e.g. example.com, group@example.com)" },
   "config_userRule_itemsLocal_placeholder_attachmentName":   { "message": "Input a term per line (e.g. important, confidential)" },
   "config_userRule_itemsLocal_placeholder_attachmentSuffix": { "message": "Input a file extension per line (e.g. .exe, .pdf)" },
   "config_userRule_itemsLocal_placeholder_subject":          { "message": "Input a term per line (e.g. important, confidential)" },
@@ -184,7 +184,7 @@
   "config_userRule_itemsLocal_description":                  { "message": ": wildcards (* and ?) are available." },
   "config_userRule_itemsFile_caption":                             { "message": "Use a list given as a file" },
   "config_userRule_itemsFile_button_label":                        { "message": "Choose…" },
-  "config_userRule_itemsFile_button_dialogTitle_recipientDomain":  { "message": "Choose a list of domain names" },
+  "config_userRule_itemsFile_button_dialogTitle_recipientDomain":  { "message": "Choose a list of domain names and addresses" },
   "config_userRule_itemsFile_button_dialogTitle_attachmentName":   { "message": "Choose a list of temrs" },
   "config_userRule_itemsFile_button_dialogTitle_attachmentSuffix": { "message": "Choose a list of file extensions" },
   "config_userRule_itemsFile_button_dialogTitle_subject":          { "message": "Choose a list of temrs" },
@@ -206,11 +206,11 @@
   "config_userRule_confirmMessage_caption_subjectOrBody":    { "message": "Message for confirmation (\"%S\" will be filled with found terms):" },
 
 
-  "config_attentionDomains_caption": { "message": "Specially alerted external domains in recipients" },
-  "config_blockedDomains_caption": { "message": "Blocked domains in recipients" },
-  "config_attentionSuffixesConfirm_label": { "message": "Confirm me again before send, if there is any attachment with one of these extensions in a message to external domains" },
-  "config_attentionSuffixes2Confirm_label": { "message": "Confirm me more again before send, if there is any attachment with one of these extensions in a message to external domains" },
-  "config_attentionTermsConfirm_label": { "message": "Confirm me again before send, if there is any attachment name with one of these terms in a message to external domains" },
+  "config_attentionDomains_caption": { "message": "Specially alerted external domains and addresses in recipients" },
+  "config_blockedDomains_caption": { "message": "Blocked domains and addresses in recipients" },
+  "config_attentionSuffixesConfirm_label": { "message": "Confirm me again before send, if there is any attachment with one of these extensions in a message to external recipients" },
+  "config_attentionSuffixes2Confirm_label": { "message": "Confirm me more again before send, if there is any attachment with one of these extensions in a message to external recipients" },
+  "config_attentionTermsConfirm_label": { "message": "Confirm me again before send, if there is any attachment name with one of these terms in a message to external recipients" },
 
   "config_attachments_caption": { "message": "Attachments" },
 

--- a/webextensions/_locales/ja/messages.json
+++ b/webextensions/_locales/ja/messages.json
@@ -4,8 +4,8 @@
 
 
   "confirmDialogTitle": { "message": "宛先メールアドレスの確認" },
-  "confirmDialogInternalsCaption": { "message": "登録済みドメインのメールアドレス" },
-  "confirmDialogExternalsCaption": { "message": "外部ドメインのメールアドレス" },
+  "confirmDialogInternalsCaption": { "message": "登録済みドメイン・組織内のメールアドレス" },
+  "confirmDialogExternalsCaption": { "message": "外部ドメイン・組織外のメールアドレス" },
   "confirmDialogSubjectCaption": { "message": "件名: " },
   "confirmDialogBodyCaption": { "message": "本文" },
   "confirmDialogAttachmentsCaption": { "message": "添付ファイル" },
@@ -145,7 +145,7 @@
   "config_userRule_enabled_tooltiptext": { "message": "チェックをONにするとルールが有効になります" },
 
   "config_userRule_matchTarget_caption":          { "message": "マッチング対象:" },
-  "config_userRule_matchTarget_recipientDomain":  { "message": "宛先のドメイン名部分" },
+  "config_userRule_matchTarget_recipientDomain":  { "message": "宛先のアドレス部分" },
   "config_userRule_matchTarget_attachmentName":   { "message": "添付ファイルの名前" },
   "config_userRule_matchTarget_attachmentSuffix": { "message": "添付ファイルの拡張子" },
   "config_userRule_matchTarget_subject":          { "message": "件名" },
@@ -175,7 +175,7 @@
   "config_userRule_action_blockExternalsWithAttachments": { "message": "外部のアドレスが宛先に含まれ、且つ添付ファイルがある時だけ送信を禁止する" },
 
   "config_userRule_itemsLocal_caption":                      { "message": "手動編集のリストを使用" },
-  "config_userRule_itemsLocal_placeholder_recipientDomain":  { "message": "ドメイン名を1行ずつ入力（例：example.com）" },
+  "config_userRule_itemsLocal_placeholder_recipientDomain":  { "message": "ドメイン名またはアドレスを1行ずつ入力（例：example.com、group@example.com）" },
   "config_userRule_itemsLocal_placeholder_attachmentName":   { "message": "語句を1行ずつ入力（例：危険、社外秘）" },
   "config_userRule_itemsLocal_placeholder_attachmentSuffix": { "message": "ファイルの拡張子を1行ずつ入力（例：.exe、.pdf）" },
   "config_userRule_itemsLocal_placeholder_subject":          { "message": "語句を1行ずつ入力（例：危険、社外秘）" },
@@ -184,7 +184,7 @@
   "config_userRule_itemsLocal_description":                  { "message": "：ワイルドカード（*および?）を使用可能です" },
   "config_userRule_itemsFile_caption":                             { "message": "ファイル形式のリストを使用" },
   "config_userRule_itemsFile_button_label":                        { "message": "参照..." },
-  "config_userRule_itemsFile_button_dialogTitle_recipientDomain":  { "message": "ドメインのリストを選択" },
+  "config_userRule_itemsFile_button_dialogTitle_recipientDomain":  { "message": "ドメイン名およびアドレスのリストを選択" },
   "config_userRule_itemsFile_button_dialogTitle_attachmentName":   { "message": "語句のリストを選択" },
   "config_userRule_itemsFile_button_dialogTitle_attachmentSuffix": { "message": "拡張子のリストを選択" },
   "config_userRule_itemsFile_button_dialogTitle_subject":          { "message": "語句のリストを選択" },
@@ -206,16 +206,16 @@
   "config_userRule_confirmMessage_caption_subjectOrBody":    { "message": "警告のメッセージ (\"%S\" と書いた位置に語句が入ります):" },
 
 
-  "config_attentionDomains_caption": { "message": "特別に注意が必要な外部ドメインの宛先" },
-  "config_blockedDomains_caption": { "message": "送信を禁止する宛先" },
+  "config_attentionDomains_caption": { "message": "特別に注意が必要な外部ドメイン・アドレスの宛先" },
+  "config_blockedDomains_caption": { "message": "送信を禁止する外部ドメイン・アドレスの宛先" },
   "config_requireCheckAttachment_label": { "message": "添付ファイルの確認を求める" },
-  "config_attentionSuffixesConfirm_label": { "message": "これらの拡張子を持つファイルが外部ドメイン宛のメールに添付されている場合は再度警告する" },
-  "config_attentionSuffixes2Confirm_label": { "message": "これらの拡張子を持つファイルが外部ドメイン宛のメールに添付されている場合はさらに再度警告する" },
-  "config_attentionTermsConfirm_label": { "message": "これらの語句を名前の一部に持つファイルが外部ドメイン宛のメールに添付されている場合は再度警告する" },
+  "config_attentionSuffixesConfirm_label": { "message": "これらの拡張子を持つファイルが外部宛のメールに添付されている場合は再度警告する" },
+  "config_attentionSuffixes2Confirm_label": { "message": "これらの拡張子を持つファイルが外部宛のメールに添付されている場合はさらに再度警告する" },
+  "config_attentionTermsConfirm_label": { "message": "これらの語句を名前の一部に持つファイルが外部宛のメールに添付されている場合は再度警告する" },
 
   "config_attachments_caption": { "message": "添付ファイル" },
 
-  "config_requireReinputAttachmentNames_label": { "message": "宛先に外部ドメインのアドレスがある場合、添付ファイル名の手動での入力を求める" },
+  "config_requireReinputAttachmentNames_label": { "message": "外部ドメイン・アドレスの宛先がある場合、添付ファイル名の手動での入力を求める" },
   "config_allowCheckAllAttachments_label": { "message": "添付ファイルのチェックボックスの一括制御を許可" },
 
 
@@ -228,7 +228,7 @@
   "config_requireCheckSubject_label": { "message": "件名の確認を求める" },
   "config_requireCheckBody_label": { "message": "メール本文の確認を求める" },
 
-  "config_highlightExternalDomains_label": { "message": "外部ドメインの宛先のアドレスを強調表示する" },
+  "config_highlightExternalDomains_label": { "message": "外部の宛先のアドレスを強調表示する" },
   "config_largeFontSizeForAddresses_label": { "message": "メールアドレスを大きなフォントサイズで表示する" },
   "config_alwaysLargeDialog_label": { "message": "確認のダイアログを常に大きなサイズで開く" },
   "config_topMessage_label": { "message": "確認のダイアログの冒頭メッセージ:" },

--- a/webextensions/common/recipient-classifier.js
+++ b/webextensions/common/recipient-classifier.js
@@ -27,7 +27,7 @@ export class RecipientClassifier {
       uniquePatterns.delete(negativeItem);
       uniquePatterns.delete(`-${negativeItem}`);
     }
-    this.$internalDomainsMatcher = new RegExp(`^(${[...uniquePatterns].map(pattern => this.$toRegExpSource(pattern)).join('|')})$`, 'i');
+    this.$internalPatternsMatcher = new RegExp(`^(${[...uniquePatterns].map(pattern => this.$toRegExpSource(pattern)).join('|')})$`, 'i');
     this.classify = this.classify.bind(this);
   }
 
@@ -49,7 +49,7 @@ export class RecipientClassifier {
         ...RecipientParser.parse(recipient),
       };
       const address = classifiedRecipient.address;
-      if (this.$internalDomainsMatcher.test(address))
+      if (this.$internalPatternsMatcher.test(address))
         internals.add(classifiedRecipient);
       else
         externals.add(classifiedRecipient);

--- a/webextensions/test/test-matching-rules.js
+++ b/webextensions/test/test-matching-rules.js
@@ -307,6 +307,24 @@ const RECIPIENT_DOMAIN_RULES = [
     ] },
 ];
 
+const RECIPIENT_ADDRESS_RULES = [
+  { id:          'highlighted by recipient address always',
+    matchTarget: Constants.MATCH_TO_RECIPIENT_DOMAIN,
+    highlight:   Constants.HIGHLIGHT_ALWAYS,
+    itemsLocal:  ['*+highlighted-always@example.com'] },
+  { id:          'highlighted by recipient address always, but disabled by comment',
+    matchTarget: Constants.MATCH_TO_RECIPIENT_DOMAIN,
+    highlight:   Constants.HIGHLIGHT_ALWAYS,
+    itemsLocal:  ['#*+never-highlighted-with-comment@example.com'] },
+  { id:          'highlighted by recipient address always, but disabled by negative modifier',
+    matchTarget: Constants.MATCH_TO_RECIPIENT_DOMAIN,
+    highlight:   Constants.HIGHLIGHT_ALWAYS,
+    itemsLocal:  [
+      '*+never-highlighted-with-negative-modifier@example.com',
+      '-*+never-highlighted-with-negative-modifier@example.com',
+    ] },
+];
+
 const ATTACHMENT_NAME_RULES = [
   { id:          'highlighted by attachment name',
     matchTarget: Constants.MATCH_TO_ATTACHMENT_NAME,
@@ -518,6 +536,7 @@ const RULES = [
   ...NO_REACTION_RULES,
   ...DISABLED_RULES,
   ...RECIPIENT_DOMAIN_RULES,
+  ...RECIPIENT_ADDRESS_RULES,
   ...ATTACHMENT_NAME_RULES,
   ...ATTACHMENT_SUFFIX_RULES,
   ...SUBJECT_RULES,
@@ -533,6 +552,7 @@ const RECONFIRM_ACTIONS = new Set([
 ]);
 const RECONFIRM_RULES = [
   ...RECIPIENT_DOMAIN_RULES,
+  ...RECIPIENT_ADDRESS_RULES,
   ...ATTACHMENT_NAME_RULES,
   ...ATTACHMENT_SUFFIX_RULES,
   ...SUBJECT_RULES,
@@ -549,6 +569,7 @@ const BLOCK_ACTIONS = new Set([
 ]);
 const BLOCK_RULES = [
   ...RECIPIENT_DOMAIN_RULES,
+  ...RECIPIENT_ADDRESS_RULES,
   ...ATTACHMENT_NAME_RULES,
   ...ATTACHMENT_SUFFIX_RULES,
   ...SUBJECT_RULES,
@@ -562,6 +583,7 @@ const RECIPIENTS_HIGHLIGHTED_ALWAYS = [
   'lowercase@highlighted-always.example.com',
   'uppercase@HIGHLIGHTED-ALWAYS.CLEAR-CODE.COM',
   'mixedcase@HiGhLiGhTeD-aLwAyS.ExAmPlE.cOm',
+  'local+highlighted-always@example.com',
 ];
 const RECIPIENTS_HIGHLIGHTED_WITH_ATTACHMENTS = [
   'lowercase@highlighted-attachment.example.com',
@@ -620,9 +642,11 @@ const RECIPIENTS_BLOCKED_EXTERNALS_WITH_ATTACHMENTS = [
 ];
 const RECIPIENTS_NOT_HIGHLIGHTED_WITH_COMMENT = [
   'address@never-highlighted-with-comment.example.com',
+  'local+never-highlighted-with-comment@example.com',
 ];
 const RECIPIENTS_NOT_HIGHLIGHTED_WITH_NEGATIVE_MODIFIER = [
   'address@never-highlighted-with-negative-modifier.clear-code.com',
+  'local+never-highlighted-with-negative-modifier@example.com',
 ];
 
 const RECIPIENTS = [

--- a/webextensions/test/test-matching-rules.js
+++ b/webextensions/test/test-matching-rules.js
@@ -761,14 +761,14 @@ const ATTACHMENTS = [
 function recipientsToAddresses(classified) {
   return Object.fromEntries(
     Object.entries(classified)
-      .map(([id, recipients]) => [id, recipients.map(recipient => recipient.address)])
+      .map(([id, recipients]) => [id, recipients.map(recipient => recipient.address).sort()])
   );
 }
 
 function attachmentsToNames(classified) {
   return Object.fromEntries(
     Object.entries(classified)
-      .map(([id, attachments]) => [id, attachments.map(attachment => attachment.name)])
+      .map(([id, attachments]) => [id, attachments.map(attachment => attachment.name).sort()])
   );
 }
 
@@ -782,11 +782,11 @@ export async function test_classifyRecipients() {
       ...RECIPIENTS_HIGHLIGHTED_ALWAYS,
       'address-like@highlighted-always.CLEAR-code.com',
       ...RECIPIENTS_HIGHLIGHTED_EXTERNALS,
-    ],
+    ].sort(),
     [...matchingRules.getHighlightedRecipientAddresses({
       externals:   RECIPIENTS,
       attachments: [],
-    })]
+    })].sort()
   );
   is(
     [
@@ -795,11 +795,11 @@ export async function test_classifyRecipients() {
       ...RECIPIENTS_HIGHLIGHTED_WITH_ATTACHMENTS,
       ...RECIPIENTS_HIGHLIGHTED_EXTERNALS,
       ...RECIPIENTS_HIGHLIGHTED_EXTERNALS_WITH_ATTACHMENTS,
-    ],
+    ].sort(),
     [...matchingRules.getHighlightedRecipientAddresses({
       externals:   RECIPIENTS,
       attachments: ATTACHMENTS,
-    })]
+    })].sort()
   );
 
   is(
@@ -807,8 +807,10 @@ export async function test_classifyRecipients() {
       'reconfirmed by recipient domain always': [
         ...RECIPIENTS_RECONFIRMED_ALWAYS,
         'address-like@reconfirmed-always.CLEAR-code.com',
-      ],
-      'reconfirmed by recipient domain only external': RECIPIENTS_RECONFIRMED_EXTERNALS,
+      ].sort(),
+      'reconfirmed by recipient domain only external': [
+        ...RECIPIENTS_RECONFIRMED_EXTERNALS,
+      ].sort(),
     },
     recipientsToAddresses(matchingRules.classifyReconfirmRecipients({
       externals:   RECIPIENTS,
@@ -820,10 +822,16 @@ export async function test_classifyRecipients() {
       'reconfirmed by recipient domain always': [
         ...RECIPIENTS_RECONFIRMED_ALWAYS,
         'address-like@reconfirmed-always.CLEAR-code.com',
-      ],
-      'reconfirmed by recipient domain only with attachment': RECIPIENTS_RECONFIRMED_WITH_ATTACHMENTS,
-      'reconfirmed by recipient domain only external': RECIPIENTS_RECONFIRMED_EXTERNALS,
-      'reconfirmed by recipient domain only external with attachment': RECIPIENTS_RECONFIRMED_EXTERNALS_WITH_ATTACHMENTS,
+      ].sort(),
+      'reconfirmed by recipient domain only with attachment': [
+        ...RECIPIENTS_RECONFIRMED_WITH_ATTACHMENTS,
+      ].sort(),
+      'reconfirmed by recipient domain only external': [
+        ...RECIPIENTS_RECONFIRMED_EXTERNALS,
+      ].sort(),
+      'reconfirmed by recipient domain only external with attachment': [
+        ...RECIPIENTS_RECONFIRMED_EXTERNALS_WITH_ATTACHMENTS,
+      ].sort(),
     },
     recipientsToAddresses(matchingRules.classifyReconfirmRecipients({
       externals:   RECIPIENTS,
@@ -836,8 +844,10 @@ export async function test_classifyRecipients() {
       'blocked by recipient domain always': [
         ...RECIPIENTS_BLOCKED_ALWAYS,
         'address-like@blocked-always.example.com',
-      ],
-      'blocked by recipient domain only external': RECIPIENTS_BLOCKED_EXTERNALS,
+      ].sort(),
+      'blocked by recipient domain only external': [
+        ...RECIPIENTS_BLOCKED_EXTERNALS,
+      ].sort(),
     },
     recipientsToAddresses(matchingRules.classifyBlockRecipients({
       externals:   RECIPIENTS,
@@ -849,10 +859,16 @@ export async function test_classifyRecipients() {
       'blocked by recipient domain always': [
         ...RECIPIENTS_BLOCKED_ALWAYS,
         'address-like@blocked-always.example.com',
-      ],
-      'blocked by recipient domain only with attachment': RECIPIENTS_BLOCKED_WITH_ATTACHMENTS,
-      'blocked by recipient domain only external': RECIPIENTS_BLOCKED_EXTERNALS,
-      'blocked by recipient domain only external with attachment': RECIPIENTS_BLOCKED_EXTERNALS_WITH_ATTACHMENTS,
+      ].sort(),
+      'blocked by recipient domain only with attachment': [
+        ...RECIPIENTS_BLOCKED_WITH_ATTACHMENTS,
+      ].sort(),
+      'blocked by recipient domain only external': [
+        ...RECIPIENTS_BLOCKED_EXTERNALS,
+      ].sort(),
+      'blocked by recipient domain only external with attachment': [
+        ...RECIPIENTS_BLOCKED_EXTERNALS_WITH_ATTACHMENTS,
+      ].sort(),
     },
     recipientsToAddresses(matchingRules.classifyBlockRecipients({
       externals:   RECIPIENTS,
@@ -869,11 +885,11 @@ export async function test_classifyAttachments() {
     [
       ...ATTACHMENTS_HIGHLIGHTED_NAME,
       ...ATTACHMENTS_HIGHLIGHTED_SUFFIX,
-    ],
+    ].sort(),
     [...matchingRules.getHighlightedAttachmentNames({
       attachments: ATTACHMENTS,
       hasExternal: false,
-    })]
+    })].sort()
   );
   is(
     [
@@ -881,21 +897,21 @@ export async function test_classifyAttachments() {
       ...ATTACHMENTS_HIGHLIGHTED_NAME_EXTERNALS,
       ...ATTACHMENTS_HIGHLIGHTED_SUFFIX,
       ...ATTACHMENTS_HIGHLIGHTED_SUFFIX_EXTERNALS,
-    ],
+    ].sort(),
     [...matchingRules.getHighlightedAttachmentNames({
       attachments: ATTACHMENTS,
       hasExternal: true,
-    })]
+    })].sort()
   );
 
   is(
     {
       'reconfirmed by attachment name': [
         ...ATTACHMENTS_RECONFIRMED_NAME,
-      ],
+      ].sort(),
       'reconfirmed by attachment suffix': [
         ...ATTACHMENTS_RECONFIRMED_SUFFIX,
-      ],
+      ].sort(),
     },
     attachmentsToNames(matchingRules.classifyReconfirmAttachments({
       attachments: ATTACHMENTS,
@@ -906,16 +922,16 @@ export async function test_classifyAttachments() {
     {
       'reconfirmed by attachment name': [
         ...ATTACHMENTS_RECONFIRMED_NAME,
-      ],
+      ].sort(),
       'reconfirmed by attachment name only external': [
         ...ATTACHMENTS_RECONFIRMED_NAME_EXTERNALS,
-      ],
+      ].sort(),
       'reconfirmed by attachment suffix': [
         ...ATTACHMENTS_RECONFIRMED_SUFFIX,
-      ],
+      ].sort(),
       'reconfirmed by attachment suffix only external': [
         ...ATTACHMENTS_RECONFIRMED_SUFFIX_EXTERNALS,
-      ],
+      ].sort(),
     },
     attachmentsToNames(matchingRules.classifyReconfirmAttachments({
       attachments: ATTACHMENTS,
@@ -927,10 +943,10 @@ export async function test_classifyAttachments() {
     {
       'blocked by attachment name': [
         ...ATTACHMENTS_BLOCKED_NAME,
-      ],
+      ].sort(),
       'blocked by attachment suffix': [
         ...ATTACHMENTS_BLOCKED_SUFFIX,
-      ],
+      ].sort(),
     },
     attachmentsToNames(matchingRules.classifyBlockAttachments({
       attachments: ATTACHMENTS,
@@ -941,16 +957,16 @@ export async function test_classifyAttachments() {
     {
       'blocked by attachment name': [
         ...ATTACHMENTS_BLOCKED_NAME,
-      ],
+      ].sort(),
       'blocked by attachment name only external': [
         ...ATTACHMENTS_BLOCKED_NAME_EXTERNALS,
-      ],
+      ].sort(),
       'blocked by attachment suffix': [
         ...ATTACHMENTS_BLOCKED_SUFFIX,
-      ],
+      ].sort(),
       'blocked by attachment suffix only external': [
         ...ATTACHMENTS_BLOCKED_SUFFIX_EXTERNALS,
-      ],
+      ].sort(),
     },
     attachmentsToNames(matchingRules.classifyBlockAttachments({
       attachments: ATTACHMENTS,


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

This is a followup of #43. It adds address support for internal recipient patterns but extra rules are not supported. This adds address support for extra rules also.

# How to verify the fixed issue:

Define and activate an extra rule with local part and try confirmation.

## The steps to verify:

1. Define/activate an extra rule as:
   * Matching target: recipient address
   * Use a manually managed list
   * Input `*+danger@example.com`
   * Highlight on matched: Always
   * When the condition matched: Re-confirm always
3. Composite a message with recipients `mail@example.com` and `mail+danger@example.com`, and try to send it.

## Expected result:

* `mail+danger@example.com` is highlighted in the confirmation dialog.
* `mail+danger@example.com` is reconfirmed when you click "Send" in the confirmation dialog.
