### PR TITLE
Bump version to 4.2.2

### DIFF
--- a/webextensions/manifest.json
+++ b/webextensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "author": "ClearCode Inc.",
   "description": "__MSG_extensionDescription__",
   "permissions": [

--- a/webextensions/native-messaging-host/host.go
+++ b/webextensions/native-messaging-host/host.go
@@ -19,7 +19,7 @@ import (
 	"time"
 )
 
-const VERSION = "4.1.7";
+const VERSION = "4.2.2";
 
 
 var RunInCLI bool


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

This increments the minor version.


# How to verify the fixed issue:

Build XPI, install it, and confirm the version became 4.2.2.

## The steps to verify:

1. Run `cd webextensions && make`.
2. Install the built XPI to Thunderbird via the Add-ons Manager.
3. See details of the installed FlexConfirmMail.

## Expected result:

* The version number is 4.2.2.