### PR TITLE
Localize tooltip of buttons

### DIFF
--- a/webextensions/options/init.js
+++ b/webextensions/options/init.js
@@ -240,15 +240,15 @@ function rebuildUserRulesUI() {
                     </select></label></p>
           <button id=${safeAttrValue('userRule-ui-button-moveUp:' + id)}
                   class="userRule-button-moveUp ${configs.allowRearrangeRules ? '' : 'hidden'}"
-                  title="config_userRules_moveUp_tooltiptext"
+                  title="${safeLocalizedText('config_userRules_moveUp_tooltiptext')}"
                  >${safeLocalizedText('config_userRules_moveUp_label')}</button>
           <button id=${safeAttrValue('userRule-ui-button-moveDown:' + id)}
                   class="userRule-button-moveDown ${configs.allowRearrangeRules ? '' : 'hidden'}"
-                  title="config_userRules_moveDown_tooltiptext"
+                  title="${safeLocalizedText('config_userRules_moveDown_tooltiptext')}"
                  >${safeLocalizedText('config_userRules_moveDown_label')}</button>
           <button id=${safeAttrValue('userRule-ui-button-remove:' + id)}
                   class="userRule-button-remove ${configs.allowRemoveRules ? '' : 'hidden'}"
-                  title="config_userRules_remove_tooltiptext"
+                  title="${safeLocalizedText('config_userRules_remove_tooltiptext')}"
                  >${safeLocalizedText('config_userRules_remove_label')}</button>
         </div>
         <ul id=${safeAttrValue('userRule-ui-itemsSource-group:' + id)}>


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

"Move Up", "Move Down" and "Remove" buttons of extra rules are not translated unexpectedly.
This applies localized messages for these buttons as their tooltip text.

# How to verify the fixed issue:

Go to the options page and point those buttons.

## The steps to verify:

1. Start Thunderbird.
2. Install this addon.
3. Open addons manager.
4. Click "Options" button for this addon.
5. Scroll the options page down and point right-top-edge buttons of an extra rule.

## Expected result:

The tooltip text is localized.
> Describe the obvious situation to verify.
