### PR TITLE
Hide "add rule" button if allowAddRules is false

### DIFF
--- a/webextensions/options/init.js
+++ b/webextensions/options/init.js
@@ -398,6 +398,8 @@ function rebuildUserRulesUI() {
     setUserRuleFieldValue(`#userRule-ui-confirmTitle\\:${id}`,   rule.confirmTitle);
     setUserRuleFieldValue(`#userRule-ui-confirmMessage\\:${id}`, rule.confirmMessage);
   }
+
+  document.querySelector('#userRulesAddButtonContainer').classList.toggle('hidden', !configs.allowAddRules);
 }
 
 function throttledRebuildUserRulesUI() {


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

There is an internal option "allowAddRules" to disallow users to add new rules, but it is not applied correctly and the "add new rule" button is still available even if "allowAddRules" is "false".
This PR hides the button with "allowAddRules"="false".

# How to verify the fixed issue:

## The steps to verify:

1. Start Thunderbird.
2. Go to addons manager.
3. Install this addon.
4. Click the "options" button of this addon.
5. Scroll to the bottom of the options page.
6. Activate "Debug mode".
7. Set "allowAddRules" to "false".
8. Close the options page.
9. Go to the addons manager and click the "options" button of this addon again.

## Expected result:

There is no button below the extra rules section.
