### PR TITLE
Bump version embedded in the native messaging host

### DIFF
--- a/webextensions/native-messaging-host/host.go
+++ b/webextensions/native-messaging-host/host.go
@@ -19,7 +19,7 @@ import (
 	"time"
 )
 
-const VERSION = "4.2.2";
+const VERSION = "4.2.3";
 
 
 var RunInCLI bool


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

This just increments the version number embedded in the native messaging host.

# How to verify the fixed issue:

## The steps to verify:

1. Build the native messaging host.
2. Run the built binary with "-v" option.

## Expected result:

It reports 4.2.3.