### PR TITLE
Bump minVersion to 91.

### DIFF
--- a/webextensions/manifest.json
+++ b/webextensions/manifest.json
@@ -30,7 +30,7 @@
   "applications": {
     "gecko": {
       "id": "flexible-confirm-mail@clear-code.com",
-      "strict_min_version": "78.4.0"
+      "strict_min_version": "91.0"
     }
   }
 }


### PR DESCRIPTION
Because the argument of accounts.list() was introduced at Tb 91.

# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

This fixes the mismatched information mentioned at #56

# How to verify the fixed issue:

## The steps to verify:

1. Build XPI.
2. Start Thunderbird 78.
3. Try to install the built XPI.
4. Start Thunderbird 91.
5. Try to install the built XPI.

## Expected result:

Thunderbird 78 rejects the XPI as unsupported.
Thunderbird 91 accepts the XPI.
