### PR TITLE
Bump version of actions/upload-artifact

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -35,7 +35,7 @@ jobs:
           dir
           xcopy /I /Y .\webextensions\native-messaging-host\*.msi .
       - name: Upload assets
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Assets
           path: |


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

It is announced that the actions/upload-artifact@v3 will be closing down by 2025-01-30. We need to migrate to v4.
https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes
https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md

# How to verify the fixed issue:

## The steps to verify:

1. Run the workflow.

## Expected result:

The result should have built binaries as artifacts.