### PR TITLE
Fix mismatched placeholder name

### DIFF
--- a/webextensions/_locales/en/messages.json
+++ b/webextensions/_locales/en/messages.json
@@ -26,7 +26,7 @@
   "confirmNewDomainRecipientsDialogTitle": { "message": "Recipients with domains not included in the recipients of the original message" },
   "confirmNewDomainRecipientsDialogMessage": { "message": "There are recipients with domains not included in the recipients of the original message.\n\n<strong>$RECIPIENTS$</strong>\n\nDo you really want to send this message?",
     "placeholders": {
-      "domains": { "content": "$1", "example": "user@example.com" }
+      "recipients": { "content": "$1", "example": "user@example.com" }
     }},
   "confirmNewDomainRecipientsAccept": { "message": "Send" },
   "confirmNewDomainRecipientsCancel": { "message": "Cancel" },


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

This fixes mismatched placeholder name of a locale definition. It should fix a problem of a confirmation dialog: the embedded recipients are missing.

# How to verify the fixed issue:

## The steps to verify:

1. Configure FlexConfirmMail to show confirmation for newly added recipient domains.
2. Run Thunderbird with English locale.
3. Prepare an existing message.
4. Start to compose a reply for the message.
5. Add a new recipient `mail@example.org` or something which has a new domain different from any existing recipients of the message, as a Bcc (or To/Cc).
6. Try to send the message and see the confirmation dialog.
7. Check all and continue.

## Expected result:

An extra confirmation dialog should appear with a message like:

```
There are recipients with domains not included in the recipients of the original message.

(recipient addresses successfully embedded)

Do you really want to send this message?
```
