### PR TITLE
Populate list for draft

### DIFF
--- a/webextensions/background/background.js
+++ b/webextensions/background/background.js
@@ -59,10 +59,17 @@ browser.runtime.onMessage.addListener((message, sender) => {
         const author = await getAddressFromIdentity(details.identityId);
         mAuthorForTab.set(sender.tab.id, author);
         log('author ', author);
+        const [
+          to, cc, bcc,
+        ] = await Promise.all([
+          ListUtils.populateListAddresses(details.to || details.recipients || []),
+          ListUtils.populateListAddresses(details.cc || details.ccList || []),
+          ListUtils.populateListAddresses(details.bcc || details.bccList || []),
+        ]);
         mInitialRecipientsForTab.set(sender.tab.id, [...new Set([
-          ...(details.to || details.recipients || []),
-          ...(details.cc || details.ccList || []),
-          ...(details.bcc || details.bccList || []),
+          ...to,
+          ...cc,
+          ...bcc,
         ])].filter(recipient => !!recipient));
         log('initialRecipients ', mInitialRecipientsForTab.get(sender.tab.id));
         const signature = getMessageSignature({

--- a/webextensions/background/background.js
+++ b/webextensions/background/background.js
@@ -337,7 +337,7 @@ async function tryConfirm(tab, details, opener) {
   const type = mDetectedMessageTypeForTab.get(tab.id);
   log('type ', type);
   const newRecipientDomains = new Set();
-  const initialRecipients = mInitialRecipientsForTab.get(tab.id);
+  const initialRecipients = mInitialRecipientsForTab.get(tab.id) || [];
   log('initialRecipients ', initialRecipients);
   if (type != TYPE_NEWLY_COMPOSED &&
       type != TYPE_TEMPLATE &&

--- a/webextensions/common/recipient-parser.js
+++ b/webextensions/common/recipient-parser.js
@@ -6,6 +6,14 @@
 'use strict';
 
 export function parse(recipient) {
+  if (/\s*([^<@]+)\s*<\1>\s*$/.test(recipient)) { // list like "list-name <list-name>"
+    return {
+      recipient,
+      address: '',
+      domain: '',
+    };
+  }
+
   const address = /<([^@]+@[^>]+)>\s*$/.test(recipient) ? RegExp.$1 : recipient;
   const domain = address.split('@')[1].toLowerCase();
   return {

--- a/webextensions/manifest.json
+++ b/webextensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "author": "ClearCode Inc.",
   "description": "__MSG_extensionDescription__",
   "permissions": [

--- a/webextensions/test/test-recipient-parser.js
+++ b/webextensions/test/test-recipient-parser.js
@@ -1,0 +1,57 @@
+/*
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+'use strict';
+
+import * as RecipientParser from '../common/recipient-parser.js';
+import { assert } from 'tiny-esm-test-runner';
+const { is } = assert;
+
+
+test_parse.parameters = {
+  addressOnly: {
+    input: 'mail@example.com',
+    expected: {
+      recipient: 'mail@example.com',
+      address:   'mail@example.com',
+      domain:    'example.com',
+    },
+  },
+  withComment: {
+    input: '氏名 <mail@example.com>',
+    expected: {
+      recipient: '氏名 <mail@example.com>',
+      address:   'mail@example.com',
+      domain:    'example.com',
+    },
+  },
+  withCommentLikeAddress: {
+    input: '氏名@所属 <mail@example.com>',
+    expected: {
+      recipient: '氏名@所属 <mail@example.com>',
+      address:   'mail@example.com',
+      domain:    'example.com',
+    },
+  },
+  withAddressComment: {
+    input: 'mail@example.com <mail@example.com>',
+    expected: {
+      recipient: 'mail@example.com <mail@example.com>',
+      address:   'mail@example.com',
+      domain:    'example.com',
+    },
+  },
+  list: {
+    input: '組織 <組織>',
+    expected: {
+      recipient: '組織 <組織>',
+      address:   '',
+      domain:    '',
+    },
+  },
+};
+export async function test_parse({ input, expected }) {
+  is(expected, RecipientParser.parse(input));
+}


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

When a draft "下書き" message contains any mailing list (like "my-company <my-company>", it is populated to real email addresses when the message is really sent) as its recipients, FlexConfirmMail fails to populate them and cannot send the message. This change solves the limitation.

# How to verify the fixed issue:

## The steps to verify:

1. Hit Ctrl-Shift-B to open the address book.
2. Prepare multiple contacts in an address book.
3. Highlight multiple contacts with Shift/Ctrl-click.
4. Click the "New Address List" button in the rightmost pane.
5. Fill "Name" and "Nickname" fields.
6. Click "OK" button to save the list.
7. Start to composite a message.
8. Hit F9 o show the address sidebar.
9. Double-click a list (ex. the one created at the step 4).
10. The name of the list appears in the "To" field.
11. Save the message as a draft.
12. Close the composition window.
13. Go to the Draft folder and double-click the message saved at the  step 11.
14. Fill subject and body.
15. Try to send the message.

## Expected result:

* The list is successfully populated and all email addresses are listed in the confirmation dialog.
* Successfully sent the message if you confirmed.
