### PR TITLE
Bump version to 4.2.5

### DIFF
--- a/webextensions/manifest.json
+++ b/webextensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "author": "ClearCode Inc.",
   "description": "__MSG_extensionDescription__",
   "permissions": [

--- a/webextensions/native-messaging-host/host.go
+++ b/webextensions/native-messaging-host/host.go
@@ -20,7 +20,7 @@ import (
 	"time"
 )
 
-const VERSION = "4.2.3"
+const VERSION = "4.2.5"
 
 var RunInCLI bool
 var DebugLogs []string


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

This just bumps the version number for the next release.

# How to verify the fixed issue:

## The steps to verify:

1. Build the XPI and the native messaging host.
2. See their version.

## Expected result:

It is 4.2.5.