### PR TITLE
Fix mismatched placeholder in zh_CN locale

### DIFF
--- a/webextensions/_locales/zh_CN/messages.json
+++ b/webextensions/_locales/zh_CN/messages.json
@@ -26,7 +26,7 @@
   "confirmNewDomainRecipientsDialogTitle": { "message": "收件人添加了原邮件收件人中未包含的域名地址" },
   "confirmNewDomainRecipientsDialogMessage": { "message": "收件人添加了以下原邮件收件人中未包含的域名地址。\n\n<strong>$RECIPIENTS$</strong>\n\n请确认是否要发送此邮件？",
     "placeholders": {
-      "domains": { "content": "$1", "example": "user@example.com" }
+      "recipients": { "content": "$1", "example": "user@example.com" }
     }},
   "confirmNewDomainRecipientsAccept": { "message": "发送" },
   "confirmNewDomainRecipientsCancel": { "message": "取消" },


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

I unexpectedly re-introduced the already fixed bug #62 to a newly translated entry. This applies same change to the zh_CN locale.

# How to verify the fixed issue:

## The steps to verify:

1. Configure FlexConfirmMail to show confirmation for newly added recipient domains.
2. Run Thunderbird with Chinese (zh-CN) locale.
3. Prepare an existing message.
4. Start to compose a reply for the message.
5. Add a new recipient `mail@example.org` or something which has a new domain different from any existing recipients of the message, as a Bcc (or To/Cc).
6. Try to send the message and see the confirmation dialog.
7. Check all and continue.

## Expected result:

An extra confirmation dialog should appear with a message like:

```
收件人添加了以下原邮件收件人中未包含的域名地址。

(recipient addresses successfully embedded)

请确认是否要发送此邮件？
```
