### PR TITLE
Restore height of the confirmation dialog window correctly #59

### DIFF
--- a/webextensions/background/background.js
+++ b/webextensions/background/background.js
@@ -368,7 +368,7 @@ async function tryConfirm(tab, details, opener) {
     modal:  !configs.debug,
     opener,
     width:  configs.confirmDialogWidth,
-    height: configs.confirmDialogWidth
+    height: configs.confirmDialogHeight,
   };
   if (configs.alwaysLargeDialog) {
     dialogParams.width = Math.max(


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

There is a typo to refer stored window height when the confirmation dialog is opened. This fixes the misrestoration.

# How to verify the fixed issue:

## The steps to verify:

1. Start to compose a new message.
2. Enter a recipient which has external address.
3. Try to send the composed message.
4. FlexConfirmMail's confirmation dialog appears. Resize it with different length for width and height, for example: 1000x500.
5. Cancel it.
6. Re-try to send the message.

## Expected result:

The confirmation dialog appears with its last size, ex: 1000x500.