### PR TITLE
Deactivate "check all" features completely if they are disabled

### DIFF
--- a/webextensions/dialog/confirm/confirm.js
+++ b/webextensions/dialog/confirm/confirm.js
@@ -199,11 +199,13 @@ configs.$loaded.then(async () => {
 
 function initInternals() {
   log('initInternals ', mParams.internals);
-  mInternalsAllCheck.disabled = mParams.internals.length == 0;
+  mInternalsAllCheck.disabled = !configs.allowCheckAllInternals || mParams.internals.length == 0;
   mInternalsAllCheck.classList.toggle('hidden', !configs.allowCheckAllInternals);
-  mInternalsAllCheck.addEventListener('change', _event => {
-    checkAll(mInternalsList, mInternalsAllCheck.checked);
-  });
+  if (configs.allowCheckAllInternals) {
+    mInternalsAllCheck.addEventListener('change', _event => {
+      checkAll(mInternalsList, mInternalsAllCheck.checked);
+    });
+  }
   mInternalsList.addEventListener('change', _event => {
     mInternalsAllCheck.checked = isAllChecked(mInternalsList);
   });
@@ -221,14 +223,16 @@ function initInternals() {
 
 function initExternals() {
   log('initExternals ', mParams.externals);
-  mExternalsAllCheck.disabled = mParams.externals.length == 0;
+  mExternalsAllCheck.disabled = !configs.allowCheckAllExternals || mParams.externals.length == 0;
   mExternalsAllCheck.classList.toggle('hidden', !configs.allowCheckAllExternals);
-  mExternalsAllCheck.addEventListener('change', _event => {
-    checkAll(mExternalsList, mExternalsAllCheck.checked);
-    for (const domainRow of mExternalsList.querySelectorAll('.row.domain')) {
-      domainRow.classList.toggle('checked', mExternalsAllCheck.checked);
-    }
-  });
+  if (configs.allowCheckAllExternals) {
+    mExternalsAllCheck.addEventListener('change', _event => {
+      checkAll(mExternalsList, mExternalsAllCheck.checked);
+      for (const domainRow of mExternalsList.querySelectorAll('.row.domain')) {
+        domainRow.classList.toggle('checked', mExternalsAllCheck.checked);
+      }
+    });
+  }
   mExternalsList.addEventListener('change', event => {
     const row = event.target.closest('.row');
     const domainRow = mExternalsList.querySelector(`.row.domain[data-domain="${row.dataset.domain}"]`);
@@ -307,11 +311,13 @@ function initAttachments() {
   if (!configs.requireCheckAttachment)
     return;
 
-  mAttachmentsAllCheck.disabled = configs.requireReinputAttachmentNames || (mParams.attachments.length == 0);
+  mAttachmentsAllCheck.disabled = !configs.allowCheckAllAttachments || configs.requireReinputAttachmentNames || (mParams.attachments.length == 0);
   mAttachmentsAllCheck.classList.toggle('hidden', !configs.allowCheckAllAttachments);
-  mAttachmentsAllCheck.addEventListener('change', _event => {
-    checkAll(mAttachmentsList, mAttachmentsAllCheck.checked);
-  });
+  if (configs.allowCheckAllAttachments) {
+    mAttachmentsAllCheck.addEventListener('change', _event => {
+      checkAll(mAttachmentsList, mAttachmentsAllCheck.checked);
+    });
+  }
   mAttachmentsList.addEventListener('change', _event => {
     mAttachmentsAllCheck.checked = isAllChecked(mAttachmentsList);
   });


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#72

# What this PR does / why we need it:

"Check all" checkboxes are still effective with clicking on corresponding labels, even if they are hidden.
This PR completely deactivate reactions of "check all" checkboxes.

# How to verify the fixed issue:

## The steps to verify:

1. Configure FlexConfirmMail to deactivate "check all" checkboxes for internal recipients, external recipients and attachments.
2. Create a message with any internal recipients, any external recipients, and any attachment.
3. Try to send the message, to show the confirmation dialog.
4. On the confirmation dialog, try clicking on all section titles above checkboxes.

## Expected result:

* Section titles do nothing.
* When all checkboxes are checked manually, the "Send" button is activated.