### PR TITLE
Support whitespaces in list names

### DIFF
--- a/webextensions/_locales/en/messages.json
+++ b/webextensions/_locales/en/messages.json
@@ -15,6 +15,14 @@
   "confirmDialogCancel": { "message": "Cancel" },
 
 
+  "confirmUnpopulatableListsTitle": { "message": "Mailing lists impossible to confirm" },
+  "confirmUnpopulatableListsMessage": { "message": "There are mailing lists impossible to confirm their members.\n\n<strong>$LISTS$</strong>\n\nDo you really want to send this message?",
+    "placeholders": {
+      "lists": { "content": "$1", "example": "list <list>" }
+    }},
+  "confirmUnpopulatableListsAccept": { "message": "Send" },
+  "confirmUnpopulatableListsCancel": { "message": "Cancel" },
+
   "confirmMultipleRecipientDomainsTitle": { "message": "Multiple recipient domains in To or Cc" },
   "confirmMultipleRecipientDomainsMessage": { "message": "There are multiple recipient domains in To or Cc.\n\n<strong>$DOMAINS$</strong>\n\nAll recipients information will be disclosed to all other recipients. Do you really want to send this message?",
     "placeholders": {
@@ -116,6 +124,7 @@
   "config_allowCheckAllExternals_label": { "message": "Allow to make all external recipients to be checked with one checkbox" },
   "config_confirmNewDomainRecipients_label": { "message": "Confirm when any recipients with domains different from any existing recipients are added" },
   "config_emphasizeNewDomainRecipients_label": { "message": "Emphasize added recipients with domains different from any existing recipients" },
+  "config_confirmUnpopulatableLists_label": { "message": "Alert when there is any mailing list impossible to see its members in recipients" },
 
 
   "config_userRules_caption":              { "message": "More Rules" },

--- a/webextensions/_locales/ja/messages.json
+++ b/webextensions/_locales/ja/messages.json
@@ -15,6 +15,14 @@
   "confirmDialogCancel": { "message": "キャンセル" },
 
 
+  "confirmUnpopulatableListsTitle": { "message": "メンバーを確認できないメーリングリスト" },
+  "confirmUnpopulatableListsMessage": { "message": "メンバーを確認できないメーリングリストが宛先に含まれています。\n\n<strong>$LISTS$</strong>\n\n送信してよろしいですか？",
+    "placeholders": {
+      "lists": { "content": "$1", "example": "list <list>" }
+    }},
+  "confirmUnpopulatableListsAccept": { "message": "送信" },
+  "confirmUnpopulatableListsCancel": { "message": "キャンセル" },
+
   "confirmMultipleRecipientDomainsTitle": { "message": "複数のドメインがToまたはCcの宛先に含まれています" },
   "confirmMultipleRecipientDomainsMessage": { "message": "ToまたはCcの宛先に複数のドメインが含まれています。\n\n<strong>$DOMAINS$</strong>\n\n送信すると、他の宛先の情報が全ての宛先に通知されます。送信してよろしいですか？",
     "placeholders": {
@@ -116,6 +124,7 @@
   "config_allowCheckAllExternals_label": { "message": "外部の宛先の一括チェックを許可" },
   "config_confirmNewDomainRecipients_label": { "message": "返信の宛先に今まで含まれていなかったドメインのアドレスが追加された場合に警告する" },
   "config_emphasizeNewDomainRecipients_label": { "message": "返信の宛先に今まで含まれていなかったドメインのアドレスを強調表示する" },
+  "config_confirmUnpopulatableLists_label": { "message": "メンバーを確認できないメーリングリストが宛先に含まれる場合に警告する" },
 
 
   "config_userRules_caption":              { "message": "追加のルール" },

--- a/webextensions/_locales/zh_CN/messages.json
+++ b/webextensions/_locales/zh_CN/messages.json
@@ -15,6 +15,14 @@
   "confirmDialogCancel": { "message": "取消" },
 
 
+  "confirmUnpopulatableListsTitle": { "message": "Mailing lists impossible to confirm" },
+  "confirmUnpopulatableListsMessage": { "message": "There are mailing lists impossible to confirm their members.\n\n<strong>$LISTS$</strong>\n\n请确认是否要发送此邮件？",
+    "placeholders": {
+      "lists": { "content": "$1", "example": "list <list>" }
+    }},
+  "confirmUnpopulatableListsAccept": { "message": "发送" },
+  "confirmUnpopulatableListsCancel": { "message": "取消" },
+
   "confirmMultipleRecipientDomainsTitle": { "message": "多个域被包含在收件人或抄送目的地中" },
   "confirmMultipleRecipientDomainsMessage": { "message": "收件人或抄送目的地包含一个以上的域。\n\n<strong>$DOMAINS$</strong>\n\n一旦发送，所有其他目的地将被告知。 你确定你要发送这个吗？",
     "placeholders": {

--- a/webextensions/background/background.js
+++ b/webextensions/background/background.js
@@ -59,13 +59,10 @@ browser.runtime.onMessage.addListener((message, sender) => {
         const author = await getAddressFromIdentity(details.identityId);
         mAuthorForTab.set(sender.tab.id, author);
         log('author ', author);
-        const [
-          to, cc, bcc,
-        ] = await Promise.all([
-          ListUtils.populateListAddresses(details.to || details.recipients || []),
-          ListUtils.populateListAddresses(details.cc || details.ccList || []),
-          ListUtils.populateListAddresses(details.bcc || details.bccList || []),
-        ]);
+        const { to, cc, bcc, failedLists } = await ListUtils.populateAllListAddresses(details);
+        if (failedLists.length > 0) {
+          log('We could not populate lists: ', failedLists);
+        }
         mInitialRecipientsForTab.set(sender.tab.id, [...new Set([
           ...to,
           ...cc,
@@ -318,14 +315,7 @@ function classifyRecipients({ to, cc, bcc }) {
 
 async function tryConfirm(tab, details, opener) {
   log('tryConfirm: ', tab, details, opener);
-  const [
-    to, cc, bcc,
-  ] = await Promise.all([
-    ListUtils.populateListAddresses(details.to),
-    ListUtils.populateListAddresses(details.cc),
-    ListUtils.populateListAddresses(details.bcc),
-  ]);
-
+  const { to, cc, bcc, failedLists } = await ListUtils.populateAllListAddresses(details);
   const { internals, externals } = classifyRecipients({ to, cc, bcc });
 
   if (configs.skipConfirmationForInternalMail &&
@@ -394,31 +384,24 @@ async function tryConfirm(tab, details, opener) {
       externals: [...externals],
       attachments: details.attachments || await browser.compose.listAttachments(tab.id),
       newRecipientDomains: [...newRecipientDomains],
+      failedLists,
     }
   );
 }
 
 async function shouldBlock(tab, details) {
-  await applyOutlookGPOConfigs();
-
-  const matchingRules = new MatchingRules(configs);
-  const [
-    to, cc, bcc, attachments,
-  ] = await Promise.all([
-    ListUtils.populateListAddresses(details.to),
-    ListUtils.populateListAddresses(details.cc),
-    ListUtils.populateListAddresses(details.bcc),
-    details.attachments || browser.compose.listAttachments(tab.id),
-    matchingRules.populate(readFile),
-  ]);
-
-  const { internals, externals } = classifyRecipients({ to, cc, bcc });
-
   try {
+    log('shouldBlock ', tab, details);
+    const matchingRules = new MatchingRules(configs);
+    await matchingRules.populate(readFile);
+
+    const { internals, externals } = classifyRecipients(details);
+    log('  recipients: ', { internals, externals });
+
     const blocked = await matchingRules.tryBlock({
       internals,
       externals,
-      attachments,
+      attachments: details.attachments,
       subject: details.subject,
       body: details.body,
       alert: async ({ title, message }) => {
@@ -446,10 +429,20 @@ async function shouldBlock(tab, details) {
 browser.compose.onBeforeSend.addListener(async (tab, details) => {
   log('onBeforeSend ', tab, details);
   await configs.$loaded;
-  const composeWin = await browser.windows.get(tab.windowId);
-  log('onBeforeSend: composeWin = ', composeWin);
 
-  if (await shouldBlock(tab, details)) {
+  const [
+    composeWin,
+    recipients,
+    attachments,
+  ] = await Promise.all([
+    browser.windows.get(tab.windowId),
+    ListUtils.populateAllListAddresses(details),
+    details.attachments || browser.compose.listAttachments(tab.id),
+    applyOutlookGPOConfigs(),
+  ]);
+  log('onBeforeSend: composeWin = ', composeWin, `, recipients = ${JSON.stringify(recipients)}, attachments = ${JSON.stringify(attachments)}`);
+
+  if (await shouldBlock(tab, { ...details, ...recipients, attachments })) {
     log(' => blocked');
     return { cancel: true };
   }

--- a/webextensions/common/common.js
+++ b/webextensions/common/common.js
@@ -184,6 +184,7 @@ export const configs = new Configs({
 
   skipConfirmationForInternalMail: false,
 
+  confirmUnpopulatableLists: true,
   confirmMultipleRecipientDomains: false,
   minConfirmMultipleRecipientDomainsCount: 2,
   minConfirmationRecipientsCount: 0,

--- a/webextensions/common/recipient-parser.js
+++ b/webextensions/common/recipient-parser.js
@@ -6,7 +6,7 @@
 'use strict';
 
 export function parse(recipient) {
-  if (/\s*([^<@]+)\s*<\1>\s*$/.test(recipient)) { // list like "list-name <list-name>"
+  if (/\s*([^<@]+)\s*<(?:\1|"\1")>\s*$/.test(recipient)) { // list like "list-name <list-name>"
     return {
       recipient,
       address: '',
@@ -15,7 +15,8 @@ export function parse(recipient) {
   }
 
   const address = /<([^@]+@[^>]+)>\s*$/.test(recipient) ? RegExp.$1 : recipient;
-  const domain = address.split('@')[1].toLowerCase();
+  const parts = address.split('@');
+  const domain = parts.length > 1 ? parts[1].toLowerCase() : '';
   return {
     recipient,
     address,

--- a/webextensions/options/options.html
+++ b/webextensions/options/options.html
@@ -51,6 +51,7 @@
        <label><input id="minConfirmMultipleRecipientDomainsCount" type="number" size="4"
              >__MSG_config_minConfirmMultipleRecipientDomainsCount_label_after__</label></p>
     <p><label><input id="confirmNewDomainRecipients" type="checkbox">__MSG_config_confirmNewDomainRecipients_label__</label></p>
+    <p><label><input id="confirmUnpopulatableLists" type="checkbox">__MSG_config_confirmUnpopulatableLists_label__</label></p>
 
     <hr class="spacer">
 

--- a/webextensions/test/test-recipient-parser.js
+++ b/webextensions/test/test-recipient-parser.js
@@ -51,6 +51,14 @@ test_parse.parameters = {
       domain:    '',
     },
   },
+  list: {
+    input: '組 織 <組 織>',
+    expected: {
+      recipient: '組 織 <組 織>',
+      address:   '',
+      domain:    '',
+    },
+  },
 };
 export async function test_parse({ input, expected }) {
   is(expected, RecipientParser.parse(input));


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Mailing list can have whitespaces, like `mailing list <mailing list>`. Current implementation cannot detect such cases and treats them as regular recipients. As the result such invalid recipients throw errors and the addon fails further operations. This PR introduces some safe guards.

# How to verify the fixed issue:

## The steps to verify:

1. Create a mailing list with a name containing whitespaces, like "mailing list". It should have members with non-internal addresses.
2. Start composition a new message.
3. Set "mailing list <mailing list>" as a recipient.
4. Try to send the message.

## Expected result:

The confirmation dialog is shown with populated addresses.