### PR TITLE
Rename to FlexConfirmMail Stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PACKAGE_NAME = flex-confirm-mail
+PACKAGE_NAME = flex-confirm-mail-stable
 
 .PHONY: xpi lint host
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For example, if you use the `policies.json`:
 }
 ```
 
-It will help you to create such an managed storage manifest with exported configs: FlexConfirmMail options => "Development" => Check "Debug mode" => "All Configs" => "Export".
+It will help you to create such an managed storage manifest with exported configs: FlexConfirmMail Stable options => "Development" => Check "Debug mode" => "All Configs" => "Export".
 (Please remind that you should remove `"debug":true` from the managed manifest.)
 
 ## For Developers
@@ -70,7 +70,7 @@ It will help you to create such an managed storage manifest with exported config
 4. Start Thunderbird.
 5. Open the Add-ons Manager.
 6. Drag downloaded XPI file and drop it to the Add-ons Manager.
-7. Accept installation of the new FlexConfirmMail.
+7. Accept installation of the new FlexConfirmMail Stable.
 8. Open `sample.eml` with Thunderbird.
 9. Hit Ctrl-E to edit the mail as a new message.
 10. Try to send it.
@@ -157,7 +157,7 @@ And, on macOS:
    2. Run `cd webextensions` and `./make_msi.bat` on `cmd.exe` to build MSI packages.
    3. Build the package for macOS.
    4. Rename built packages with the version number, like as:
-      * `flex-confirm-mail-we-x.x.x.xpi`
+      * `flex-confirm-mail-stable-we-x.x.x.xpi`
       * `flex-confirm-mail-nmh-without-installer-x.x.x.zip`
       * `flex-confirm-mail-nmh-386-x.x.x.msi`
       * `flex-confirm-mail-nmh-amd64-x.x.x.msi`
@@ -175,7 +175,7 @@ And, on macOS:
 9. Publish XPI to the addons store.
    1. Go to the [dashboard](https://addons.thunderbird.net/developers/).
    2. Log in with the account `firefox-support@clear-code.com`.
-   3. Go to the [edit page of the FlexConfirmMail](https://addons.thunderbird.net/developers/addon/flex-confirm-mail/edit).
+   3. Go to the [edit page of the FlexConfirmMail Stable](https://addons.thunderbird.net/developers/addon/flex-confirm-mail-stable/edit).
    4. Click the link "Upload New Version".
    5. Upload the built XPI.
    6. Check to "Thunderbird" and continue.

--- a/webextensions/Makefile
+++ b/webextensions/Makefile
@@ -20,7 +20,7 @@ format: install_dependency
 
 xpi: init_extlib install_extlib lint
 	rm -f ./*.xpi
-	zip -r -9 flex-confirm-mail-we.xpi manifest.json common background dialog options resources extlib _locales -x '*/.*' >/dev/null 2>/dev/null
+	zip -r -9 flex-confirm-mail-stable-we.xpi manifest.json common background dialog options resources extlib _locales -x '*/.*' >/dev/null 2>/dev/null
 
 init_extlib:
 	git submodule update --init

--- a/webextensions/_locales/en/messages.json
+++ b/webextensions/_locales/en/messages.json
@@ -1,5 +1,5 @@
 {
-  "extensionName": { "message": "FlexConfirmMail" },
+  "extensionName": { "message": "FlexConfirmMail Stable" },
   "extensionDescription": { "message": "Confirm mailaddress and attachments based on flexible rules." },
 
 

--- a/webextensions/_locales/ja/messages.json
+++ b/webextensions/_locales/ja/messages.json
@@ -1,5 +1,5 @@
 {
-  "extensionName": { "message": "FlexConfirmMail" },
+  "extensionName": { "message": "FlexConfirmMail Stable" },
   "extensionDescription": { "message": "柔軟なルールに基づいて、送信前に宛先のアドレスや添付ファイルの確認を行うようにします。" },
 
 

--- a/webextensions/_locales/zh_CN/messages.json
+++ b/webextensions/_locales/zh_CN/messages.json
@@ -1,5 +1,5 @@
 {
-  "extensionName": { "message": "FlexConfirmMail" },
+  "extensionName": { "message": "FlexConfirmMail Stable" },
   "extensionDescription": { "message": "确保在发送前根据灵活的规则检查目的地地址和附件" },
 
 

--- a/webextensions/native-messaging-host/wix.json
+++ b/webextensions/native-messaging-host/wix.json
@@ -25,7 +25,7 @@
   },
   "choco": {
     "description": "Native Messaging Host for FlexConfirmMail",
-    "project-url": "https://github.com/clear-code/flex-confirm-mail-stable",
+    "project-url": "https://github.com/FlexConfirmMail/Thunderbird/tree/stable",
     "tags": "thunderbird addon",
     "license-url": "https://github.com/clear-code/flex-confirm-mail-stable/blob/master/webextensions/native-messaging-host/LICENSE"
   }

--- a/webextensions/native-messaging-host/wix.json
+++ b/webextensions/native-messaging-host/wix.json
@@ -27,6 +27,6 @@
     "description": "Native Messaging Host for FlexConfirmMail",
     "project-url": "https://github.com/FlexConfirmMail/Thunderbird/tree/stable",
     "tags": "thunderbird addon",
-    "license-url": "https://github.com/clear-code/flex-confirm-mail-stable/blob/master/webextensions/native-messaging-host/LICENSE"
+    "license-url": "https://github.com/FlexConfirmMail/Thunderbird/tree/stable/webextensions/native-messaging-host/LICENSE"
   }
 }

--- a/webextensions/native-messaging-host/wix.json
+++ b/webextensions/native-messaging-host/wix.json
@@ -25,8 +25,8 @@
   },
   "choco": {
     "description": "Native Messaging Host for FlexConfirmMail",
-    "project-url": "https://github.com/clear-code/flex-confirm-mail",
+    "project-url": "https://github.com/clear-code/flex-confirm-mail-stable",
     "tags": "thunderbird addon",
-    "license-url": "https://github.com/clear-code/flex-confirm-mail/blob/master/webextensions/native-messaging-host/LICENSE"
+    "license-url": "https://github.com/clear-code/flex-confirm-mail-stable/blob/master/webextensions/native-messaging-host/LICENSE"
   }
 }


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

This PR changes the display name of the addon to "FlexConfirmMail Stable", and updates URLs of the public webpage.
Some resources including the Native Messaging Host still don't have "stable" suffix - we'll rename them if needed in the future.

# How to verify the fixed issue:

## The steps to verify:

1. Build the XPI.
2. Install it to Thunderbird.

## Expected result:

The display name has the suffix "Stable".
The built XPI also have the suffix.