### PR TITLE
Reassign internal ID for non-stable releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For example, if you use the `policies.json`:
   "policies": {
     "3rdparty": {
       "Extensions": {
-        "flexible-confirm-mail@clear-code.com": {
+        "flexible-confirm-mail-progressive@clear-code.com": {
           "internalDomains": [
             "clear-code.com"
           ],

--- a/webextensions/managed-storage-examples/policies.json
+++ b/webextensions/managed-storage-examples/policies.json
@@ -2,7 +2,7 @@
   "policies": {
     "3rdparty": {
       "Extensions": {
-        "flexible-confirm-mail@clear-code.com": {
+        "flexible-confirm-mail-progressive@clear-code.com": {
           "// 宛先": 0,
 
           "// 送信前の宛先確認: 0=確認しない, 1=常に確認, 2=宛先が変更された時だけ確認": 0,

--- a/webextensions/manifest.json
+++ b/webextensions/manifest.json
@@ -29,7 +29,7 @@
   "default_locale": "en",
   "applications": {
     "gecko": {
-      "id": "flexible-confirm-mail@clear-code.com",
+      "id": "flexible-confirm-mail-progressive@clear-code.com",
       "strict_min_version": "91.0"
     }
   }

--- a/webextensions/native-messaging-host/com.clear_code.flexible_confirm_mail_we_host.macos.json
+++ b/webextensions/native-messaging-host/com.clear_code.flexible_confirm_mail_we_host.macos.json
@@ -4,6 +4,7 @@
   "path": "/Library/Application Support/Mozilla/NativeMessagingHosts/com.clear_code.flexible_confirm_mail_we_host/host",
   "type": "stdio",
   "allowed_extensions": [
-    "flexible-confirm-mail@clear-code.com"
+    "flexible-confirm-mail@clear-code.com",
+    "flexible-confirm-mail-progressive@clear-code.com"
   ]
 }

--- a/webextensions/native-messaging-host/com.clear_code.flexible_confirm_mail_we_host.windows.json
+++ b/webextensions/native-messaging-host/com.clear_code.flexible_confirm_mail_we_host.windows.json
@@ -4,6 +4,7 @@
   "path": "host.exe",
   "type": "stdio",
   "allowed_extensions": [
-    "flexible-confirm-mail@clear-code.com"
+    "flexible-confirm-mail@clear-code.com",
+    "flexible-confirm-mail-progressive@clear-code.com"
   ]
 }


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

We are planning to separate update channels of this addon as:

* Regular channel: Based on the master branch. Any destructive changes may be merged. Published as https://addons.thunderbird.net/thunderbird/addon/flex-confirm-mail/ or https://addons.thunderbird.net/thunderbird/addon/flex-confirm-mail-progressive/
* Stable channel: Based on the stable branch from 4.2.5. Only screened and verified changes will be merged. Published as https://addons.thunderbird.net/thunderbird/addon/flex-confirm-mail-stable/

This PR changes the internal ID for the regular channel.

# How to verify the fixed issue:

## The steps to verify:

1. Build the XPI.
2. Install it to Thunderbird.

## Expected result:

The display name has no suffix.
The built XPI have no suffix.
The internal ID is detected as `flexible-confirm-mail-progressive@clear-code.com` at about:debugging or about:support pages.